### PR TITLE
use attestationId as projectId

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,6 @@ model Project {
   twitter   String?
   mirror    String?
 
-  attestationId          String?
   openSourceObserverSlug String?
   addedTeamMembers       Boolean @default(false)
   addedFunding           Boolean @default(false)

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -51,7 +51,11 @@ const Dashboard = ({
 
         <div className="flex items-center gap-x-2">
           <Link href="/projects/new">
-            <Button variant="destructive">Add a project</Button>
+            <Button
+              variant={projects.length === 0 ? "destructive" : "secondary"}
+            >
+              Add a project
+            </Button>
           </Link>
           <Button variant="secondary">Join a project</Button>
         </div>

--- a/src/db/projects.ts
+++ b/src/db/projects.ts
@@ -76,11 +76,11 @@ export type CreateProjectParams = Partial<
 }
 
 export async function createProject({
-  farcasterId,
+  userId,
   projectId,
   project,
 }: {
-  farcasterId: string
+  userId: string
   projectId: string
   project: CreateProjectParams
 }) {
@@ -90,10 +90,10 @@ export async function createProject({
       ...project,
       team: {
         create: {
-          role: "owner" satisfies TeamRole,
+          role: "admin" satisfies TeamRole,
           user: {
             connect: {
-              farcasterId,
+              id: userId,
             },
           },
         },

--- a/src/lib/actions/projects.ts
+++ b/src/lib/actions/projects.ts
@@ -48,11 +48,9 @@ export const createNewProject = async (details: CreateProjectParams) => {
     farcasterId: session.user.farcasterId,
   })
 
-  const projectId = nanoid()
-
   const project = await createProject({
     farcasterId: session.user.farcasterId,
-    projectId,
+    projectId: attestationId,
     project: {
       ...details,
       attestationId,

--- a/src/lib/actions/projects.ts
+++ b/src/lib/actions/projects.ts
@@ -49,12 +49,9 @@ export const createNewProject = async (details: CreateProjectParams) => {
   })
 
   const project = await createProject({
-    farcasterId: session.user.farcasterId,
+    userId: session.user.id,
     projectId: attestationId,
-    project: {
-      ...details,
-      attestationId,
-    },
+    project: details,
   })
 
   revalidatePath("/dashboard")


### PR DESCRIPTION
I think it makes sense to use attestationId as a default identifier for projects since all the projects will have a unique attestation. This also makes it easier to query the projects and removes the confusion between attestationId & projectId