### PR TITLE
Track last project update to surface unpublished changes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,8 +50,9 @@ model Project {
   mirror    String?
 
   openSourceObserverSlug String?
-  addedTeamMembers       Boolean @default(false)
-  addedFunding           Boolean @default(false)
+  addedTeamMembers       Boolean  @default(false)
+  addedFunding           Boolean  @default(false)
+  lastMetadataUpdate     DateTime @default(now())
 
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
@@ -79,8 +80,8 @@ model Application {
   round   FundingRound @relation(fields: [roundId], references: [id])
   project Project      @relation(fields: [projectId], references: [id])
 
-  @@index([projectId])
   @@unique([roundId, projectId])
+  @@index([projectId])
 }
 
 model UserProjects {
@@ -96,9 +97,9 @@ model UserProjects {
   user    User    @relation(fields: [userId], references: [id])
   project Project @relation(fields: [projectId], references: [id])
 
+  @@unique([userId, projectId])
   @@index([userId])
   @@index([projectId])
-  @@unique([userId, projectId])
 }
 
 model ProjectSnapshot {
@@ -148,8 +149,8 @@ model ProjectContract {
 
   project Project @relation(fields: [projectId], references: [id])
 
-  @@index([projectId])
   @@unique([contractAddress, chainId])
+  @@index([projectId])
 }
 
 model ProjectFunding {

--- a/src/components/projects/contracts/ContractForm.tsx
+++ b/src/components/projects/contracts/ContractForm.tsx
@@ -29,7 +29,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { useToast } from "@/components/ui/use-toast"
 import { verifyContract } from "@/lib/actions/contracts"
-import { copyTextToClipBoard } from "@/lib/utils"
+import { copyToClipboard } from "@/lib/utils"
 
 import { ChainSelector } from "./ChainSelector"
 import { ContractSchema, ContractsSchema } from "./schema"
@@ -67,7 +67,7 @@ export function ContractForm({
 
   const onCopyValue = async (value: string) => {
     try {
-      await copyTextToClipBoard(value)
+      await copyToClipboard(value)
       toast({ title: "Copied to clipboard" })
     } catch (error) {
       toast({ title: "Error copying to clipboard", variant: "destructive" })

--- a/src/components/projects/publish/PublishForm.tsx
+++ b/src/components/projects/publish/PublishForm.tsx
@@ -6,7 +6,11 @@ import { useCallback, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { createProjectSnapshot } from "@/lib/actions/snapshots"
 import { ProjectWithDetails } from "@/lib/types"
-import { getProjectStatus, ProjectSection } from "@/lib/utils"
+import {
+  getProjectStatus,
+  projectHasUnpublishedChanges,
+  ProjectSection,
+} from "@/lib/utils"
 
 import { Snapshot } from "./Snapshot"
 
@@ -27,6 +31,10 @@ export const PublishForm = ({ project }: { project: ProjectWithDetails }) => {
         completedSections,
       ).length === 5
     )
+  }, [project])
+
+  const hasUnpublishedChanges = useMemo(() => {
+    return projectHasUnpublishedChanges(project)
   }, [project])
 
   const onPublish = useCallback(async () => {
@@ -75,6 +83,11 @@ export const PublishForm = ({ project }: { project: ProjectWithDetails }) => {
         {!canPublish && (
           <p className="text-sm text-destructive">
             You haven&apos;t completed all the previous steps
+          </p>
+        )}
+        {hasUnpublishedChanges && (
+          <p className="text-sm text-destructive">
+            Your recent edits haven&apos;t been published onchain
           </p>
         )}
       </div>

--- a/src/components/projects/repos/GithubForm.tsx
+++ b/src/components/projects/repos/GithubForm.tsx
@@ -5,7 +5,6 @@ import { UseFormReturn } from "react-hook-form"
 import { z } from "zod"
 
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,7 +20,7 @@ import {
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { useToast } from "@/components/ui/use-toast"
-import { copyTextToClipBoard } from "@/lib/utils"
+import { copyToClipboard } from "@/lib/utils"
 
 import { ReposFormSchema } from "./schema"
 
@@ -45,7 +44,7 @@ export const GithubForm = ({
 
   const onCopy = async () => {
     try {
-      await copyTextToClipBoard(url)
+      await copyToClipboard(url)
       toast({ title: "Copied to clipboard" })
     } catch (error) {
       toast({ title: "Error copying URL", variant: "destructive" })

--- a/src/components/projects/repos/VerifyGithubRepoDialog.tsx
+++ b/src/components/projects/repos/VerifyGithubRepoDialog.tsx
@@ -22,7 +22,7 @@ import {
   updateGithubRepo,
   verifyGithubRepo,
 } from "@/lib/actions/repos"
-import { copyTextToClipBoard } from "@/lib/utils"
+import { copyToClipboard } from "@/lib/utils"
 
 const sampleFullJson = `\
 {
@@ -279,7 +279,7 @@ const VerifyFundingStep = ({
 
   const onCopy = async () => {
     try {
-      await copyTextToClipBoard(requiredJson.replace("[projectId]", projectId))
+      await copyToClipboard(requiredJson.replace("[projectId]", projectId))
       toast({ title: "Copied to clipboard " })
     } catch (error) {
       toast({ title: "Error copying JSON", variant: "destructive" })

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -26,7 +26,10 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn(
+      "aspect-square object-cover object-center h-full w-full",
+      className,
+    )}
     {...props}
   />
 ))

--- a/src/db/projects.ts
+++ b/src/db/projects.ts
@@ -117,7 +117,10 @@ export async function updateProject({
     where: {
       id,
     },
-    data: project,
+    data: {
+      ...project,
+      lastMetadataUpdate: new Date(),
+    },
   })
 }
 
@@ -154,37 +157,7 @@ export async function getProjectTeam({ id }: { id: string }) {
       id,
     },
     include: {
-      team: {
-        include: {
-          user: true,
-        },
-      },
-    },
-  })
-}
-
-export async function addTeamMember({
-  projectId,
-  userId,
-  role = "member",
-}: {
-  projectId: string
-  userId: string
-  role?: TeamRole
-}) {
-  return prisma.userProjects.create({
-    data: {
-      role,
-      user: {
-        connect: {
-          id: userId,
-        },
-      },
-      project: {
-        connect: {
-          id: projectId,
-        },
-      },
+      team: true,
     },
   })
 }
@@ -198,13 +171,24 @@ export async function addTeamMembers({
   userIds: string[]
   role?: TeamRole
 }) {
-  return prisma.userProjects.createMany({
+  const memberCreate = prisma.userProjects.createMany({
     data: userIds.map((userId) => ({
       role,
       userId,
       projectId,
     })),
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([memberCreate, projectUpdate])
 }
 
 export async function updateMemberRole({
@@ -216,7 +200,7 @@ export async function updateMemberRole({
   userId: string
   role: TeamRole
 }) {
-  return prisma.userProjects.update({
+  const memberUpdate = prisma.userProjects.update({
     where: {
       userId_projectId: {
         projectId,
@@ -227,6 +211,17 @@ export async function updateMemberRole({
       role,
     },
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([memberUpdate, projectUpdate])
 }
 
 export async function removeTeamMember({
@@ -236,7 +231,7 @@ export async function removeTeamMember({
   projectId: string
   userId: string
 }) {
-  return prisma.userProjects.delete({
+  const memberDelete = prisma.userProjects.delete({
     where: {
       userId_projectId: {
         projectId,
@@ -244,6 +239,17 @@ export async function removeTeamMember({
       },
     },
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([memberDelete, projectUpdate])
 }
 
 export async function addProjectContract({
@@ -253,7 +259,7 @@ export async function addProjectContract({
   projectId: string
   contract: Omit<Prisma.ProjectContractCreateInput, "project">
 }) {
-  return prisma.projectContract.create({
+  const contractCreate = prisma.projectContract.create({
     data: {
       ...contract,
       project: {
@@ -263,6 +269,17 @@ export async function addProjectContract({
       },
     },
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([contractCreate, projectUpdate])
 }
 
 export async function removeProjectContract({
@@ -274,7 +291,7 @@ export async function removeProjectContract({
   address: string
   chainId: number
 }) {
-  return prisma.projectContract.delete({
+  const contractDelete = prisma.projectContract.delete({
     where: {
       projectId,
       contractAddress_chainId: {
@@ -283,6 +300,17 @@ export async function removeProjectContract({
       },
     },
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([contractDelete, projectUpdate])
 }
 
 export async function getProjectContracts({
@@ -310,7 +338,7 @@ export async function addProjectRepository({
   projectId: string
   repo: Omit<Prisma.ProjectRepositoryCreateInput, "project">
 }) {
-  return prisma.projectRepository.create({
+  const repoCreate = prisma.projectRepository.create({
     data: {
       ...repo,
       project: {
@@ -320,6 +348,17 @@ export async function addProjectRepository({
       },
     },
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([repoCreate, projectUpdate])
 }
 
 export async function removeProjectRepository({
@@ -329,12 +368,23 @@ export async function removeProjectRepository({
   projectId: string
   repositoryUrl: string
 }) {
-  return prisma.projectRepository.delete({
+  const repoDelete = prisma.projectRepository.delete({
     where: {
       projectId: projectId,
       url: repositoryUrl,
     },
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([repoDelete, projectUpdate])
 }
 
 export async function updateProjectRepository({
@@ -346,13 +396,24 @@ export async function updateProjectRepository({
   url: string
   updates: Prisma.ProjectRepositoryUpdateInput
 }) {
-  return prisma.projectRepository.update({
+  const repoUpdate = prisma.projectRepository.update({
     where: {
       projectId,
       url,
     },
     data: updates,
   })
+
+  const projectUpdate = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([repoUpdate, projectUpdate])
 }
 
 export async function updateProjectRepositories({
@@ -379,7 +440,16 @@ export async function updateProjectRepositories({
     })),
   })
 
-  return prisma.$transaction([remove, create])
+  const update = prisma.project.update({
+    where: {
+      id: projectId,
+    },
+    data: {
+      lastMetadataUpdate: new Date(),
+    },
+  })
+
+  return prisma.$transaction([remove, create, update])
 }
 
 export async function updateProjectFunding({
@@ -410,6 +480,7 @@ export async function updateProjectFunding({
     },
     data: {
       addedFunding: true,
+      lastMetadataUpdate: new Date(),
     },
   })
 

--- a/src/db/projects.ts
+++ b/src/db/projects.ts
@@ -358,7 +358,12 @@ export async function addProjectRepository({
     },
   })
 
-  return prisma.$transaction([repoCreate, projectUpdate])
+  const [repository, project] = await prisma.$transaction([
+    repoCreate,
+    projectUpdate,
+  ])
+
+  return repository
 }
 
 export async function removeProjectRepository({

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { customAlphabet } from "nanoid"
+import { sortBy } from "ramda"
 import { twMerge } from "tailwind-merge"
 
 import { ProjectWithDetails } from "../types"
@@ -19,9 +20,9 @@ export function titlecase(str: string) {
   return str.charAt(0).toLocaleUpperCase() + str.slice(1)
 }
 
-export const copyTextToClipBoard = async (url: string) => {
+export const copyToClipboard = async (value: string) => {
   try {
-    await navigator.clipboard.writeText(url)
+    await navigator.clipboard.writeText(value)
   } catch (error) {
     throw new Error("Failed to copy text to clipboard")
   }
@@ -98,6 +99,15 @@ export function getProjectStatus(project: ProjectWithDetails): ProjectStatus {
   progress += hasSnapshots ? 16.67 : 0
 
   return { completedSections, progressPercent: Math.round(progress) }
+}
+
+export function projectHasUnpublishedChanges(
+  project: ProjectWithDetails,
+): boolean {
+  const latestSnapshot = sortBy((s) => -s.createdAt, project.snapshots)[0]
+  if (!latestSnapshot) return false
+
+  return latestSnapshot.createdAt < project.lastMetadataUpdate
 }
 
 /*


### PR DESCRIPTION
- Add a new field on the project for the last metadata update timestamp
- Update this field when making changes to the project or related entities
- Surface a warning when a project has outdated snapshots
- In the future we'll also notify other places or via a toast, but the core functionality is there