### PR TITLE
Animated toasts for longer loading states

### DIFF
--- a/src/app/application/page.tsx
+++ b/src/app/application/page.tsx
@@ -4,7 +4,7 @@ import { auth } from "@/auth"
 import { ApplicationFlow } from "@/components/application"
 import { getApplications, getProjects } from "@/lib/actions/projects"
 
-// TODO: Increase API timeout since attestation creation is slow
+export const maxDuration = 60
 
 export default async function Page() {
   const session = await auth()

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css"
 
+import { Loader2 } from "lucide-react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 
@@ -33,6 +34,7 @@ export default function RootLayout({
           {children}
           <Toaster
             icons={{
+              loading: <Loader2 size={18} className="animate-spin" />,
               success: <CheckIconFilled size={18} />,
               info: <InfoIconFilled size={18} />,
             }}

--- a/src/app/projects/[projectId]/publish/page.tsx
+++ b/src/app/projects/[projectId]/publish/page.tsx
@@ -5,7 +5,7 @@ import { PublishForm } from "@/components/projects/publish/PublishForm"
 import { getProject } from "@/db/projects"
 import { isUserMember } from "@/lib/actions/utils"
 
-// TODO: Increase API timeout since attestation creation is slow
+export const maxDuration = 60
 
 export default async function Page({
   params,

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,7 +1,7 @@
 import ProjectDetailsForm from "@/components/projects/details/ProjectDetailsForm"
 import { ProjectStatusSidebar } from "@/components/projects/ProjectStatusSidebar"
 
-// TODO: May need longer runtime since creating projects is slow
+export const maxDuration = 60
 
 export default function Page() {
   return (

--- a/src/components/application/index.tsx
+++ b/src/components/application/index.tsx
@@ -1,10 +1,8 @@
 "use client"
 
 import { Application } from "@prisma/client"
-import { useCallback, useState } from "react"
-import { toast } from "sonner"
+import { useState } from "react"
 
-import { submitApplications } from "@/lib/actions/applications"
 import { ProjectWithDetails } from "@/lib/types"
 
 import { ApplicationSubmitted } from "./ApplicationSubmitted"
@@ -19,30 +17,16 @@ export const ApplicationFlow = ({
   projects: ProjectWithDetails[]
   applications: Application[]
 }) => {
-  const [submittedApplication, setSubmittedApplication] =
-    useState<Application | null>(null)
+  const [submittedApp, setSubmittedApp] = useState<Application | null>(null)
 
-  const onApply = useCallback(async (projectIds: string[]) => {
-    const result = await submitApplications(projectIds)
-    if (result.error !== null || result.applications.length === 0) {
-      toast.error("There was an error submitting your application")
-      return
-    }
-
-    setSubmittedApplication(result.applications[0])
-  }, [])
-
-  return submittedApplication ? (
-    <ApplicationSubmitted
-      className={className}
-      application={submittedApplication}
-    />
+  return submittedApp ? (
+    <ApplicationSubmitted className={className} application={submittedApp} />
   ) : (
     <FundingApplication
       className={className}
       projects={projects}
       applications={applications}
-      onApply={onApply}
+      onApplied={setSubmittedApp}
     />
   )
 }


### PR DESCRIPTION
- Add loading/success/error toasts to the actions which publish onchain attestations
- Increase timeout of server actions for those pages to 60 seconds in case things get slow