### PR TITLE
Create a new application attestation and entry when publishing

### DIFF
--- a/prisma/migrations/20240529214307_drop_application_constraint/migration.sql
+++ b/prisma/migrations/20240529214307_drop_application_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Application_roundId_projectId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,7 +80,6 @@ model Application {
   round   FundingRound @relation(fields: [roundId], references: [id])
   project Project      @relation(fields: [projectId], references: [id])
 
-  @@unique([roundId, projectId])
   @@index([projectId])
 }
 

--- a/src/lib/actions/applications.ts
+++ b/src/lib/actions/applications.ts
@@ -11,6 +11,31 @@ import { createApplicationAttestation } from "../eas"
 import { getProjectStatus } from "../utils"
 import { verifyAdminStatus } from "./utils"
 
+export const publishAndSaveApplication = async ({
+  projectId,
+  farcasterId,
+  metadataSnapshotId,
+}: {
+  projectId: string
+  farcasterId: string
+  metadataSnapshotId: string
+}): Promise<Application> => {
+  // Publish attestation
+  const attestationId = await createApplicationAttestation({
+    farcasterId: parseInt(farcasterId),
+    projectId,
+    round: 4,
+    snapshotRef: metadataSnapshotId,
+  })
+
+  // Create application in database
+  return await createApplication({
+    projectId,
+    attestationId,
+    round: 4,
+  })
+}
+
 const createProjectApplication = async (
   projectId: string,
   farcasterId: string,
@@ -43,18 +68,10 @@ const createProjectApplication = async (
     project.snapshots,
   )[0]
 
-  const attestationId = await createApplicationAttestation({
-    farcasterId: parseInt(farcasterId),
-    projectId: project.id,
-    round: 4,
-    snapshotRef: latestSnapshot.attestationId,
-  })
-
-  // Create application
-  const application = await createApplication({
+  const application = await publishAndSaveApplication({
     projectId,
-    attestationId,
-    round: 4,
+    farcasterId,
+    metadataSnapshotId: latestSnapshot.id,
   })
 
   return {

--- a/src/lib/actions/snapshots.ts
+++ b/src/lib/actions/snapshots.ts
@@ -8,6 +8,7 @@ import { addProjectSnapshot, getProject } from "@/db/projects"
 import { createProjectMetadataAttestation } from "../eas"
 import { uploadToPinata } from "../pinata"
 import { ProjectWithDetails } from "../types"
+import { publishAndSaveApplication } from "./applications"
 import { verifyMembership } from "./utils"
 
 function formatProjectMetadata(
@@ -122,6 +123,15 @@ export const createProjectSnapshot = async (projectId: string) => {
       ipfsHash,
       attestationId,
     })
+
+    // If the project has an application, we need to publish a new one to reference this snapshot.
+    if (project.applications.length > 0) {
+      await publishAndSaveApplication({
+        projectId,
+        farcasterId: session.user.farcasterId,
+        metadataSnapshotId: snapshot.attestationId,
+      })
+    }
 
     revalidatePath("/dashboard")
     revalidatePath("/projects", "layout")


### PR DESCRIPTION
If a project has already submitted and application, but goes back and updates their metadata, then we want to publish both a metadata snapshot *and* a new application