### PR TITLE
Improve reliability of application submission

### DIFF
--- a/src/app/application/page.tsx
+++ b/src/app/application/page.tsx
@@ -4,7 +4,7 @@ import { auth } from "@/auth"
 import { ApplicationFlow } from "@/components/application"
 import { getApplications, getProjects } from "@/lib/actions/projects"
 
-export const maxDuration = 60
+export const maxDuration = 120
 
 export default async function Page() {
   const session = await auth()

--- a/src/app/projects/[projectId]/publish/page.tsx
+++ b/src/app/projects/[projectId]/publish/page.tsx
@@ -5,7 +5,7 @@ import { PublishForm } from "@/components/projects/publish/PublishForm"
 import { getProject } from "@/db/projects"
 import { isUserMember } from "@/lib/actions/utils"
 
-export const maxDuration = 60
+export const maxDuration = 120
 
 export default async function Page({
   params,

--- a/src/lib/actions/applications.ts
+++ b/src/lib/actions/applications.ts
@@ -85,26 +85,25 @@ export const submitApplications = async (projectIds: string[]) => {
 
   if (!session?.user?.id) {
     return {
+      applications: [],
       error: "Unauthorized",
     }
   }
 
-  const results = await Promise.all(
-    projectIds.map((projectId) =>
-      createProjectApplication(projectId, session.user.farcasterId),
-    ),
-  )
-
   const applications: Application[] = []
-  let error: Error | null = null
+  let error: string | null = null
 
-  results.forEach((result) => {
+  for (const projectId of projectIds) {
+    const result = await createProjectApplication(
+      projectId,
+      session.user.farcasterId,
+    )
     if (result.error === null && result.application) {
       applications.push(result.application)
     } else if (result.error) {
-      error = new Error(result.error)
+      error = result.error
     }
-  })
+  }
 
   revalidatePath("/dashboard")
 


### PR DESCRIPTION
Some teams were hitting issues when applying. There was evidence of a timeout in the Vercel logs, as well as a failure from EAS with a reverted transaction. Some mitigations:

- Bump timeout for application from 60 seconds to 120 (pretty large but we are sending txns in a loop...)
- Submit attestations sequentially rather than in parallel so we don't risk nonce collisions/reverts