### PR TITLE
Public Profile - Attestation Card - About Link

### DIFF
--- a/app/src/components/common/OutboundArrowLink.tsx
+++ b/app/src/components/common/OutboundArrowLink.tsx
@@ -23,14 +23,16 @@ function OutboundArrowLink({
       className={cn("group flex items-center gap-x-3", className)}
     >
       {icon}
-      <span className="group-hover:underline">{text}</span>
-      <Image
-        src="/assets/icons/arrow-up-right.svg"
-        width={10}
-        height={10}
-        alt="External link"
-        className="ml-1 opacity-0 group-hover:opacity-100 transition-opacity"
-      />
+      <span className="group-hover:underline inline-flex items-center">
+        {text}
+        <Image
+          src="/assets/icons/arrow-up-right.svg"
+          width={10}
+          height={10}
+          alt="External link"
+          className="opacity-0 group-hover:opacity-100 transition-opacity ml-0.5"
+        />
+      </span>
       {subtext && <span className="text-md text-gray-500">{subtext}</span>}
     </a>
   )

--- a/app/src/components/profile/public/ProfileRoles.tsx
+++ b/app/src/components/profile/public/ProfileRoles.tsx
@@ -3,6 +3,16 @@ import CheckIconRed from "@/components/icons/checkIconRed"
 import useAttestations from "@/hooks/api/useAttestations"
 import { UserWithAddresses } from "@/lib/types"
 
+const validAttestations = [
+  "Anticapture Commission",
+  "Citizen",
+  "Collective Feedback Commission",
+  "Developer Advisory Board",
+  "Grants Council",
+  "Security Council",
+  "Top 100 Delegate",
+]
+
 function ProfileRoles({ user }: { user: UserWithAddresses }) {
   const { raw: attestations } = useAttestations(
     user.addresses.map((a) => a.address),
@@ -33,6 +43,16 @@ function ProfileRoles({ user }: { user: UserWithAddresses }) {
             <div className="text-md text-secondary-foreground">
               {attestation.subtext}
             </div>
+            {validAttestations.includes(attestation.name) ? (
+              <OutboundArrowLink
+                text="About"
+                target={`https://gov.optimism.io/t/optimism-governance-glossary/9407`}
+                className="text-sm text-secondary-foreground hover:text-gray-600 mt-2 inline-flex items-center"
+              />
+            ) : (
+              <></>
+            )}
+
             <OutboundArrowLink
               text="Attestation"
               target={`https://optimism.easscan.org/attestation/view/${attestation.id}`}

--- a/app/src/components/profile/public/ProfileRoles.tsx
+++ b/app/src/components/profile/public/ProfileRoles.tsx
@@ -33,16 +33,18 @@ function ProfileRoles({ user }: { user: UserWithAddresses }) {
             <div className="text-md text-secondary-foreground">
               {attestation.subtext}
             </div>
-            <OutboundArrowLink
-              text="About"
-              target={`https://gov.optimism.io/t/optimism-governance-glossary/9407`}
-              className="text-sm text-secondary-foreground hover:text-gray-600 mt-2 inline-flex items-center"
-            />
-            <OutboundArrowLink
-              text="Attestation"
-              target={`https://optimism.easscan.org/attestation/view/${attestation.id}`}
-              className="text-sm text-secondary-foreground hover:text-gray-600 mt-2 inline-flex items-center"
-            />
+            <div className="inline-flex gap-x-2">
+              <OutboundArrowLink
+                text="About"
+                target={`https://gov.optimism.io/t/optimism-governance-glossary/9407`}
+                className="text-sm text-secondary-foreground hover:text-gray-600 mt-2 inline-flex items-center"
+              />
+              <OutboundArrowLink
+                text="Attestation"
+                target={`https://optimism.easscan.org/attestation/view/${attestation.id}`}
+                className="text-sm text-secondary-foreground hover:text-gray-600 mt-2 inline-flex items-center"
+              />
+            </div>
           </div>
         ))}
       </div>

--- a/app/src/components/profile/public/ProfileRoles.tsx
+++ b/app/src/components/profile/public/ProfileRoles.tsx
@@ -3,16 +3,6 @@ import CheckIconRed from "@/components/icons/checkIconRed"
 import useAttestations from "@/hooks/api/useAttestations"
 import { UserWithAddresses } from "@/lib/types"
 
-const validAttestations = [
-  "Anticapture Commission",
-  "Citizen",
-  "Collective Feedback Commission",
-  "Developer Advisory Board",
-  "Grants Council",
-  "Security Council",
-  "Top 100 Delegate",
-]
-
 function ProfileRoles({ user }: { user: UserWithAddresses }) {
   const { raw: attestations } = useAttestations(
     user.addresses.map((a) => a.address),
@@ -43,16 +33,11 @@ function ProfileRoles({ user }: { user: UserWithAddresses }) {
             <div className="text-md text-secondary-foreground">
               {attestation.subtext}
             </div>
-            {validAttestations.includes(attestation.name) ? (
-              <OutboundArrowLink
-                text="About"
-                target={`https://gov.optimism.io/t/optimism-governance-glossary/9407`}
-                className="text-sm text-secondary-foreground hover:text-gray-600 mt-2 inline-flex items-center"
-              />
-            ) : (
-              <></>
-            )}
-
+            <OutboundArrowLink
+              text="About"
+              target={`https://gov.optimism.io/t/optimism-governance-glossary/9407`}
+              className="text-sm text-secondary-foreground hover:text-gray-600 mt-2 inline-flex items-center"
+            />
             <OutboundArrowLink
               text="Attestation"
               target={`https://optimism.easscan.org/attestation/view/${attestation.id}`}


### PR DESCRIPTION
Adds an about link to certain attestations that match a specific criteria that links to the optimism governance glossary.

Satisifies https://github.com/voteagora/op-atlas/issues/416.