### PR TITLE
Auto advance to Contributor Page on new project creations.

### DIFF
--- a/app/src/app/projects/[projectId]/details/page.tsx
+++ b/app/src/app/projects/[projectId]/details/page.tsx
@@ -32,6 +32,7 @@ export default async function Page({
       organizations={
         userOrganizations?.organizations.map((org) => org.organization) ?? []
       }
+      isAutoAdvanceOnSave={false}
     />
   )
 }

--- a/app/src/app/projects/new/page.tsx
+++ b/app/src/app/projects/new/page.tsx
@@ -30,6 +30,7 @@ export default async function Page() {
               userOrganizations?.organizations.map((org) => org.organization) ??
               []
             }
+            isAutoAdvanceOnSave={true}
           />
         </div>
       </div>

--- a/app/src/components/projects/details/ProjectDetailsForm.tsx
+++ b/app/src/components/projects/details/ProjectDetailsForm.tsx
@@ -92,9 +92,11 @@ function fromStringObjectArr(objs: { value: string }[]) {
 export default function ProjectDetailsForm({
   project,
   organizations,
+  isAutoAdvanceOnSave = false,
 }: {
   project?: ProjectWithDetails
   organizations: Organization[]
+  isAutoAdvanceOnSave?: boolean
 }) {
   const router = useRouter()
   const { track } = useAnalytics()
@@ -267,9 +269,16 @@ export default function ProjectDetailsForm({
       toast.promise(promise, {
         loading: isCreating ? "Creating project onchain..." : "Saving project",
         success: (project) => {
-          isSave
-            ? router.replace(`/projects/${project.id}/details`)
-            : router.push(`/projects/${project.id}/contributors`)
+          if (isSave) {
+            if (isAutoAdvanceOnSave) {
+              router.push(`/projects/${project.id}/contributors`)
+            } else {
+              router.replace(`/projects/${project.id}/details`)
+            }
+          } else {
+            router.push(`/projects/${project.id}/contributors`)
+          }
+
           setIsSaving(false)
           return isCreating ? "Project created onchain!" : "Project saved"
         },


### PR DESCRIPTION
During project creation, after setting its details and hitting "Save", the user will get redirected to the contributor page. While still maintaining the functionality of reloading the details page when a user hits "Save" while editing an existing project.

Satisfies https://github.com/voteagora/op-atlas/issues/556.