### PR TITLE
Application status card improvements

### DIFF
--- a/app/src/components/home/Rounds.tsx
+++ b/app/src/components/home/Rounds.tsx
@@ -3,7 +3,7 @@
 import { Project } from "@prisma/client"
 import { useSession } from "next-auth/react"
 
-import { useAdminProjects } from "@/hooks/db/useAdminProjects"
+import { useSessionAdminProjects } from "@/hooks/db/useAdminProjects"
 import { useUserApplications } from "@/hooks/db/useUserApplications"
 import { useSessionProjects } from "@/hooks/db/useUserProjects"
 import { FUNDING_ROUNDS } from "@/lib/MissionsAndRoundData"
@@ -22,7 +22,7 @@ import { Sidebar } from "./Sidebar"
 export function Rounds({ user }: { user?: UserWithAddresses | null }) {
   const { data } = useSession()
 
-  const { data: userProjects } = useAdminProjects()
+  const { data: userProjects } = useSessionAdminProjects()
 
   return (
     <main className="flex flex-col flex-1 h-full items-center pb-12 relative">

--- a/app/src/components/home/Rounds.tsx
+++ b/app/src/components/home/Rounds.tsx
@@ -5,7 +5,7 @@ import { useSession } from "next-auth/react"
 
 import { useAdminProjects } from "@/hooks/db/useAdminProjects"
 import { useUserApplications } from "@/hooks/db/useUserApplications"
-import { useUserProjects } from "@/hooks/db/useUserProjects"
+import { useSessionProjects } from "@/hooks/db/useUserProjects"
 import { FUNDING_ROUNDS } from "@/lib/MissionsAndRoundData"
 import {
   ApplicationWithDetails,

--- a/app/src/components/missions/application/MissionApplication.tsx
+++ b/app/src/components/missions/application/MissionApplication.tsx
@@ -9,8 +9,8 @@ import { toast } from "sonner"
 import { z } from "zod"
 
 import { useMissionFromPath } from "@/hooks/db/useMissionFromPath"
-import { useUserProjects } from "@/hooks/db/useUserProjects"
-import { useUserRoundApplications } from "@/hooks/db/useUserRoundApplications"
+import { useSessionProjects } from "@/hooks/db/useUserProjects"
+import { useSessionRoundApplications } from "@/hooks/db/useUserRoundApplications"
 import { submitApplications } from "@/lib/actions/applications"
 import { ProjectWithDetails } from "@/lib/types"
 
@@ -44,7 +44,7 @@ export function MissionApplication() {
   })
 
   const { data: projects, isLoading } = useAdminProjects()
-  const { data: applications } = useUserRoundApplications(mission?.number)
+  const { data: applications } = useSessionRoundApplications(mission?.number)
 
   const [submittedApplications, setSubmittedApplications] = useState<
     Application[]

--- a/app/src/components/missions/application/MissionApplication.tsx
+++ b/app/src/components/missions/application/MissionApplication.tsx
@@ -18,7 +18,7 @@ import { ApplicationSubmitted } from "./ApplicationSubmitted"
 import EmailSignupDialog from "./dialogs/EmailSignupDialog"
 import { MissionApplicationBreadcrumbs } from "./MissionApplicationBreadcrumbs"
 import { MissionApplicationTabs } from "./MissionApplicationTabs"
-import { useAdminProjects } from "@/hooks/db/useAdminProjects"
+import { useSessionAdminProjects } from "@/hooks/db/useAdminProjects"
 import { rewardMeasurementDate } from "@/lib/MissionsAndRoundData"
 
 export const ApplicationFormSchema = z.object({
@@ -43,7 +43,7 @@ export function MissionApplication() {
     mode: "onChange",
   })
 
-  const { data: projects, isLoading } = useAdminProjects()
+  const { data: projects, isLoading } = useSessionAdminProjects()
   const { data: applications } = useSessionRoundApplications(mission?.number)
 
   const [submittedApplications, setSubmittedApplications] = useState<

--- a/app/src/components/missions/application/MissionApplicationTabs.tsx
+++ b/app/src/components/missions/application/MissionApplicationTabs.tsx
@@ -32,7 +32,7 @@ import { ApplicationSubmitted } from "./ApplicationSubmitted"
 import { ApplicationFormSchema } from "./MissionApplication"
 import { MissionApplicationBreadcrumbs } from "./MissionApplicationBreadcrumbs"
 import { MissionApplicationTerms } from "./MissionApplicationTerms"
-import { useAdminProjects } from "@/hooks/db/useAdminProjects"
+import { useSessionAdminProjects } from "@/hooks/db/useAdminProjects"
 import ExtendedLink from "@/components/common/ExtendedLink"
 
 export function MissionApplicationTabs({
@@ -52,7 +52,7 @@ export function MissionApplicationTabs({
   const router = useRouter()
 
   const { data: projects = [], isLoading: isLoadingProjects } =
-    useAdminProjects()
+    useSessionAdminProjects()
   const { data: applications = [], isLoading: isLoadingApplications } =
     useSessionRoundApplications(mission?.number)
 

--- a/app/src/components/missions/application/MissionApplicationTabs.tsx
+++ b/app/src/components/missions/application/MissionApplicationTabs.tsx
@@ -20,8 +20,8 @@ import {
 } from "@/components/ui/breadcrumb"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useMissionFromPath } from "@/hooks/db/useMissionFromPath"
-import { useUserProjects } from "@/hooks/db/useUserProjects"
-import { useUserRoundApplications } from "@/hooks/db/useUserRoundApplications"
+import { useSessionProjects } from "@/hooks/db/useUserProjects"
+import { useSessionRoundApplications } from "@/hooks/db/useUserRoundApplications"
 import { submitApplications } from "@/lib/actions/applications"
 import { FundingRoundData, MissionData } from "@/lib/MissionsAndRoundData"
 import { ApplicationWithDetails, ProjectWithDetails } from "@/lib/types"
@@ -54,7 +54,7 @@ export function MissionApplicationTabs({
   const { data: projects = [], isLoading: isLoadingProjects } =
     useAdminProjects()
   const { data: applications = [], isLoading: isLoadingApplications } =
-    useUserRoundApplications(mission?.number)
+    useSessionRoundApplications(mission?.number)
 
   useEffect(() => {
     if (projects.length > 0) {

--- a/app/src/components/missions/application/ProjectApplication.tsx
+++ b/app/src/components/missions/application/ProjectApplication.tsx
@@ -14,7 +14,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion"
 import { useMissionFromPath } from "@/hooks/db/useMissionFromPath"
-import { useUserRoundApplications } from "@/hooks/db/useUserRoundApplications"
+import { useSessionRoundApplications } from "@/hooks/db/useUserRoundApplications"
 import { FundingRoundData, MissionData } from "@/lib/MissionsAndRoundData"
 import { ProjectWithDetails } from "@/lib/types"
 import { getProjectStatus, ProjectSection } from "@/lib/utils"
@@ -62,7 +62,7 @@ export const ProjectApplication = ({
 
   const router = useRouter()
 
-  const { isLoading } = useUserRoundApplications(round?.number)
+  const { isLoading } = useSessionRoundApplications(round?.number)
 
   const { progressPercent, completedSections: completedSectionsCriteria } =
     useMemo(() => {

--- a/app/src/components/missions/details/Mission.tsx
+++ b/app/src/components/missions/details/Mission.tsx
@@ -25,7 +25,10 @@ import {
 
 import ExternalLink from "../../ExternalLink"
 import { RoundEnrolledProjectsCard } from "./RoundEnrolledProjectsCard"
-import { UserRoundApplicationStatusCard } from "./UserRoundApplicationStatusCard"
+import {
+  SessionRoundApplicationStatusCard,
+  UserRoundApplicationStatusCard,
+} from "./UserRoundApplicationStatusCard"
 
 export default function Mission() {
   const mission = useMissionFromPath()
@@ -69,7 +72,8 @@ export default function Mission() {
         {mission && new Date() > mission?.startsAt && (
           <div className="flex flex-col gap-y-6 ml-auto w-[290px] sticky top-40 h-full">
             <>
-              <UserRoundApplicationStatusCard />
+              <UserRoundApplicationStatusCard userId="53d84a3d-0b1b-4f02-b923-6528855ad8c2" />
+              <SessionRoundApplicationStatusCard />
               <RoundEnrolledProjectsCard />
             </>
           </div>

--- a/app/src/components/missions/details/Mission.tsx
+++ b/app/src/components/missions/details/Mission.tsx
@@ -72,7 +72,6 @@ export default function Mission() {
         {mission && new Date() > mission?.startsAt && (
           <div className="flex flex-col gap-y-6 ml-auto w-[290px] sticky top-40 h-full">
             <>
-              <UserRoundApplicationStatusCard userId="53d84a3d-0b1b-4f02-b923-6528855ad8c2" />
               <SessionRoundApplicationStatusCard />
               <RoundEnrolledProjectsCard />
             </>

--- a/app/src/components/missions/details/UserRoundApplicationStatusCard.tsx
+++ b/app/src/components/missions/details/UserRoundApplicationStatusCard.tsx
@@ -3,21 +3,30 @@
 import { format } from "date-fns"
 
 import { useMissionFromPath } from "@/hooks/db/useMissionFromPath"
-import { useUserProjects } from "@/hooks/db/useUserProjects"
-import { useUserRoundApplications } from "@/hooks/db/useUserRoundApplications"
+import { useSessionProjects, useUserProjects } from "@/hooks/db/useUserProjects"
+import {
+  useSessionRoundApplications,
+  useUserRoundApplications,
+} from "@/hooks/db/useUserRoundApplications"
 import {
   FundingRoundData,
   rewardMeasurementDate,
 } from "@/lib/MissionsAndRoundData"
 
 import { ApplicationStatusCard } from "./ApplicationStatusCard"
+import { useSession } from "next-auth/react"
 
-export const UserRoundApplicationStatusCard = () => {
+export const UserRoundApplicationStatusCard = ({
+  userId,
+}: {
+  userId: string | undefined
+}) => {
   const mission = useMissionFromPath()
 
   const { data: applications, isLoading: isLoadingApplications } =
-    useUserRoundApplications(mission?.number)
-  const { data: projects, isLoading: isLoadingProjects } = useUserProjects()
+    useUserRoundApplications(userId, mission?.number)
+  const { data: projects, isLoading: isLoadingProjects } =
+    useUserProjects(userId)
 
   return (
     <>
@@ -40,4 +49,9 @@ export const UserRoundApplicationStatusCard = () => {
       </div>
     </>
   )
+}
+
+export const SessionRoundApplicationStatusCard = () => {
+  const session = useSession()
+  return <UserRoundApplicationStatusCard userId={session?.data?.user.id} />
 }

--- a/app/src/components/missions/details/UserRoundApplicationStatusCard.tsx
+++ b/app/src/components/missions/details/UserRoundApplicationStatusCard.tsx
@@ -15,6 +15,7 @@ import {
 
 import { ApplicationStatusCard } from "./ApplicationStatusCard"
 import { useSession } from "next-auth/react"
+import { useAdminProjects } from "@/hooks/db/useAdminProjects"
 
 export const UserRoundApplicationStatusCard = ({
   userId,
@@ -26,7 +27,7 @@ export const UserRoundApplicationStatusCard = ({
   const { data: applications, isLoading: isLoadingApplications } =
     useUserRoundApplications(userId, mission?.number)
   const { data: projects, isLoading: isLoadingProjects } =
-    useUserProjects(userId)
+    useAdminProjects(userId)
 
   return (
     <>

--- a/app/src/hooks/db/useAdminProjects.tsx
+++ b/app/src/hooks/db/useAdminProjects.tsx
@@ -10,18 +10,26 @@ import {
 } from "@/lib/actions/projects"
 import { ApplicationWithDetails, ProjectWithDetails } from "@/lib/types"
 
-export function useAdminProjects(): {
+export function useAdminProjects(userId: string | undefined): {
+  data: ProjectWithDetails[] | undefined
+  isLoading: boolean
+  error: Error | null
+} {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["adminProjects", userId],
+    queryFn: () => getAdminProjects(userId!),
+    enabled: !!userId,
+  })
+
+  return { data, isLoading, error }
+}
+
+export function useSessionAdminProjects(): {
   data: ProjectWithDetails[] | undefined
   isLoading: boolean
   error: Error | null
 } {
   const { data: session } = useSession()
 
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["adminProjects", session?.user.id],
-    queryFn: () => getAdminProjects(session?.user.id as string),
-    enabled: !!session,
-  })
-
-  return { data, isLoading, error }
+  return useAdminProjects(session?.user.id)
 }

--- a/app/src/hooks/db/useUserProjects.tsx
+++ b/app/src/hooks/db/useUserProjects.tsx
@@ -9,18 +9,26 @@ import {
 } from "@/lib/actions/projects"
 import { ApplicationWithDetails, ProjectWithDetails } from "@/lib/types"
 
-export function useUserProjects(): {
+export function useUserProjects(userId: string | undefined): {
+  data: ProjectWithDetails[] | undefined
+  isLoading: boolean
+  error: Error | null
+} {
+  console.log(userId)
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["userProjects", userId],
+    queryFn: () => getProjects(userId!),
+    enabled: !!userId,
+  })
+
+  return { data, isLoading, error }
+}
+
+export function useSessionProjects(): {
   data: ProjectWithDetails[] | undefined
   isLoading: boolean
   error: Error | null
 } {
   const { data: session } = useSession()
-
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["userProjects", session?.user.id],
-    queryFn: () => getProjects(session?.user.id!),
-    enabled: !!session,
-  })
-
-  return { data, isLoading, error }
+  return useUserProjects(session?.user.id)
 }

--- a/app/src/hooks/db/useUserRoundApplications.tsx
+++ b/app/src/hooks/db/useUserRoundApplications.tsx
@@ -9,7 +9,20 @@ import { getUserApplicationsForRound } from "@/lib/actions/projects"
 import { ApplicationWithDetails } from "@/lib/types"
 import { useEffect, useState } from "react"
 
-export function useUserRoundApplications(roundNumber: number | undefined): {
+export function useUserRoundApplications(
+  userId: string | undefined,
+  roundNumber: number | undefined,
+) {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["userApplicationsForRound", userId],
+    queryFn: () => getUserApplicationsForRound(userId!, roundNumber!),
+    enabled: !!userId && !!roundNumber,
+  })
+
+  return { data, isLoading, error, refetch }
+}
+
+export function useSessionRoundApplications(roundNumber: number | undefined): {
   data: ApplicationWithDetails[] | undefined
   isLoading: boolean
   error: Error | null
@@ -17,36 +30,6 @@ export function useUserRoundApplications(roundNumber: number | undefined): {
     options?: RefetchOptions | undefined,
   ) => Promise<QueryObserverResult<ApplicationWithDetails[]>>
 } {
-  const { data: session } = useSession()
-
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ["userApplicationsForRound", session?.user.id],
-    queryFn: () => getUserApplicationsForRound(session?.user.id!, roundNumber!),
-    enabled: !!session && !!roundNumber,
-  })
-
-  // const session = useSession()
-
-  // console.log(session.data?.user.id)
-  // const [isMounted, setIsMounted] = useState<boolean>(false)
-
-  // useEffect(() => {
-  //   setIsMounted(true)
-
-  //   return () => {
-  //     setIsMounted(false)
-  //   }
-  // }, [])
-
-  // const { data, isLoading, error, refetch } = useQuery({
-  //   queryKey: ["userApplicationsForRound", roundNumber],
-  //   queryFn: () =>
-  //     getUserApplicationsForRound(
-  //       session.data.user.id,
-  //       roundNumber as number,
-  //     ),
-  //     enabled: session?.data?.user?.id !== undefined
-  // })
-
-  return { data, isLoading, error, refetch }
+  const session = useSession()
+  return useUserRoundApplications(session?.data?.user.id, roundNumber)
 }


### PR DESCRIPTION
There was an issue where if a user's project was also a part of an organization, then it was excluded from the hook. Now we changed the hook grab all the projects that the user is an admin of.

Also lays the groundwork for more reusable components that improve testing/reusability.

Satisfies https://github.com/voteagora/op-atlas/issues/586.