### PR TITLE
Jake/issue #591 green checkmark npm crate

### DIFF
--- a/app/src/components/missions/application/ProjectApplication.tsx
+++ b/app/src/components/missions/application/ProjectApplication.tsx
@@ -89,6 +89,12 @@ export const ProjectApplication = ({
       roundEligibilityCriteriaChecks[i] =
         project.isOnChainContract && project.contracts.length > 0
     }
+
+    if (criterion.type && criterion.type === "hasJavaScriptAndOrRustPackages") {
+      roundEligibilityCriteriaChecks[i] = project.repos.some(
+        (project) => project.npmPackage || project.crate,
+      )
+    }
   }
 
   const isSectionsCriteriaMet = sectionsCriteria.reduce(
@@ -213,7 +219,11 @@ export const ProjectApplication = ({
                   if (isCriterionComplete) {
                     icon = <CircleWithCheckmark />
                   } else {
-                    icon = <X className="w-6 h-6" color="red" />
+                    if (criterion.type === "hasJavaScriptAndOrRustPackages") {
+                      icon = <div className="w-6 h-[3px] bg-gray-400 m-1" />
+                    } else {
+                      icon = <X className="w-6 h-6" color="red" />
+                    }
                   }
                 } else {
                   icon = <div className="w-6 h-[3px] bg-gray-400 m-1" />

--- a/app/src/components/missions/application/ProjectApplication.tsx
+++ b/app/src/components/missions/application/ProjectApplication.tsx
@@ -89,12 +89,6 @@ export const ProjectApplication = ({
       roundEligibilityCriteriaChecks[i] =
         project.isOnChainContract && project.contracts.length > 0
     }
-
-    if (criterion.type && criterion.type === "hasJavaScriptAndOrRustPackages") {
-      roundEligibilityCriteriaChecks[i] = project.repos.some(
-        (project) => project.npmPackage || project.crate,
-      )
-    }
   }
 
   const isSectionsCriteriaMet = sectionsCriteria.reduce(
@@ -216,11 +210,19 @@ export const ProjectApplication = ({
                 let icon
 
                 if (criterion.type) {
-                  if (isCriterionComplete) {
-                    icon = <CircleWithCheckmark />
-                  } else {
-                    if (criterion.type === "hasJavaScriptAndOrRustPackages") {
+                  if (criterion.type === "hasJavaScriptAndOrRustPackages") {
+                    if (
+                      project.repos.some(
+                        (repo) => repo.npmPackage || repo.crate,
+                      )
+                    ) {
+                      icon = <CircleWithCheckmark />
+                    } else {
                       icon = <div className="w-6 h-[3px] bg-gray-400 m-1" />
+                    }
+                  } else {
+                    if (isCriterionComplete) {
+                      icon = <CircleWithCheckmark />
                     } else {
                       icon = <X className="w-6 h-6" color="red" />
                     }

--- a/app/src/lib/MissionsAndRoundData.tsx
+++ b/app/src/lib/MissionsAndRoundData.tsx
@@ -168,7 +168,7 @@ export const MISSIONS: MissionData[] = [
       },
       {
         reactNode: (
-          <p className="text-secondary-foreground">
+          <p className="text-secondary-foreground flex-1">
             JavaScript and Rust packages must be published on package registries
             (e.g,{" "}
             <ExternalLink className="underline" href={"https://npmjs.org"}>
@@ -181,6 +181,7 @@ export const MISSIONS: MissionData[] = [
             ) with their associated Github repo verified in OP Atlas.
           </p>
         ),
+        type: "hasJavaScriptAndOrRustPackages",
       },
     ],
     rewards: {


### PR DESCRIPTION
Adds a green checkmark if the user's project has an npm/crate repo.

*NOTE: This should not affect true eligibility. They should still be able to submit the project whether or not they have any associated npm/crate packages.

Satisfies https://github.com/voteagora/op-atlas/issues/591.