### PR TITLE
feat: keep existing mailchimp tags that dont exist in db

### DIFF
--- a/app/src/lib/api/mailchimp.ts
+++ b/app/src/lib/api/mailchimp.ts
@@ -3,7 +3,7 @@ import "server-only"
 import { Md5 } from "ts-md5"
 
 import mailchimp from "@/lib/mailchimp"
-import { arrayDifference } from "@/lib/utils/tags"
+import { arrayDifference } from "@/lib/utils"
 
 export async function updateMailchimpTags(
   users: {

--- a/app/src/lib/api/mailchimp.ts
+++ b/app/src/lib/api/mailchimp.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { Md5 } from "ts-md5"
 
 import mailchimp from "@/lib/mailchimp"
+import { arrayDifference } from "@/lib/utils/tags"
 
 export async function updateMailchimpTags(
   users: {
@@ -20,6 +21,15 @@ export async function updateMailchimpTags(
   }
 
   if (users.length > 0) {
+    const existingTagsMap = new Map<string, string[]>()
+    const existingTags = (await mailchimp.lists.getListMembersInfo(LIST_ID, {
+      fields: ["members.email_address", "members.tags"],
+      count: 9999, // There is no way to specify which emails to get the info for so we can't batch. We have to get all of them at once
+    })) as any
+    existingTags.members.forEach((member: any) => {
+      existingTagsMap.set(member.email_address, member.tags) // Pushing to Map so retrival is O(1) instead of O(n)
+    })
+
     const BATCH_SIZE = 500
     let totalUpdated = 0
 
@@ -31,10 +41,20 @@ export async function updateMailchimpTags(
         )} (${batch.length} users)`,
       )
 
+      const usersTagsDifference = new Map(
+        batch.map((user) => [
+          user.email,
+          arrayDifference(
+            existingTagsMap.get(user.email)?.map((tag: any) => tag.name) || [],
+            user.tags,
+          ),
+        ]),
+      )
+
       const results = (await mailchimp.lists.batchListMembers(LIST_ID, {
         members: batch.map((user) => ({
           email_address: user.email,
-          tags: user.tags,
+          tags: [...user.tags, ...(usersTagsDifference.get(user.email) ?? [])],
           email_type: "html",
           status: "subscribed",
         })),

--- a/app/src/lib/utils/index.ts
+++ b/app/src/lib/utils/index.ts
@@ -211,3 +211,8 @@ export function isOrganizationSetupComplete(organization: Organization) {
     organization.coverUrl
   )
 }
+
+export function arrayDifference(arr1: string[], arr2: string[]) {
+  const set2 = new Set(arr2)
+  return arr1.filter((item) => !set2.has(item))
+}

--- a/app/src/lib/utils/tags.ts
+++ b/app/src/lib/utils/tags.ts
@@ -35,3 +35,8 @@ export const fetchRecords = async (): Promise<EntityRecords> => {
 
   return result
 }
+
+export function arrayDifference(arr1: string[], arr2: string[]) {
+  const set2 = new Set(arr2)
+  return arr1.filter((item) => !set2.has(item))
+}

--- a/app/src/lib/utils/tags.ts
+++ b/app/src/lib/utils/tags.ts
@@ -35,8 +35,3 @@ export const fetchRecords = async (): Promise<EntityRecords> => {
 
   return result
 }
-
-export function arrayDifference(arr1: string[], arr2: string[]) {
-  const set2 = new Set(arr2)
-  return arr1.filter((item) => !set2.has(item))
-}


### PR DESCRIPTION
This came out as a talk with Emily - the idea is to keep the manually added tags from mailchimp and push on top of them