### PR TITLE
fix: adds thumbnailUrl to org project calls

### DIFF
--- a/app/src/db/organizations.ts
+++ b/app/src/db/organizations.ts
@@ -227,6 +227,7 @@ async function getUserOrganizationsWithDetailsFn(
           'id', p.id,
           'name', p.name,
           'description', p.description,
+          'thumbnailUrl', p."thumbnailUrl",
           'team', COALESCE(pt.team_data, '[]'),
           'repos', COALESCE((
             SELECT jsonb_agg(to_jsonb(r.*))


### PR DESCRIPTION
Solves: https://github.com/voteagora/op-atlas/issues/717.

Adds the thumbnailUrl to an organization's project calls.