### PR TITLE
fix: use project rewards amount on project profiles

### DIFF
--- a/app/src/app/project/[projectId]/components/Mission/index.tsx
+++ b/app/src/app/project/[projectId]/components/Mission/index.tsx
@@ -44,6 +44,7 @@ interface MissionProps {
   } | null
   deployedOnWorldchain?: boolean
   applicationDate?: Date
+  opReward: number | null
 }
 
 const getDateRange = (type: MissionProps["type"]) =>
@@ -93,6 +94,7 @@ export default function Mission({
   projectOSOData,
   deployedOnWorldchain,
   applicationDate,
+  opReward,
 }: MissionProps) {
   const totalGasFees = Object.values(metrics?.gasFees ?? {}).reduce(
     (acc, curr) => acc + curr,
@@ -101,7 +103,7 @@ export default function Mission({
 
   const onchainData = {
     ...(metrics ?? {}),
-    opReward: Math.round(projectOSOData?.onchainBuilderReward ?? 0),
+    opReward,
     isMember,
     deployedOnWorldchain,
     onchainBuilderEligible: projectOSOData?.onchainBuilderEligible,
@@ -109,7 +111,7 @@ export default function Mission({
 
   const devToolingData = {
     gasConsumed: totalGasFees,
-    opReward: Math.round(projectOSOData?.devToolingReward ?? 0),
+    opReward,
     onchainBuildersInAtlasCount: projectOSOData?.onchainBuildersInAtlasCount,
     topProjects: projectOSOData?.topProjects,
     isEligible: projectOSOData?.devToolingEligible,

--- a/app/src/app/project/[projectId]/page.tsx
+++ b/app/src/app/project/[projectId]/page.tsx
@@ -133,6 +133,9 @@ export default async function Page({ params }: PageProps) {
                         projectName={publicProject.name}
                         isMember={isMember}
                         deployedOnWorldchain={deployedOnWorldchain}
+                        opReward={Math.round(
+                          publicProject.onchainBuildersRewards ?? 0,
+                        )}
                         metrics={{
                           activeAddresses:
                             onchainBuildersMetrics.activeAddresses,
@@ -163,6 +166,9 @@ export default async function Page({ params }: PageProps) {
                         isMember={isMember}
                         projectName={publicProject.name}
                         projectOSOData={projectOSOData}
+                        opReward={Math.round(
+                          publicProject.devToolingRewards ?? 0,
+                        )}
                         metrics={{
                           activeAddresses:
                             onchainBuildersMetrics.activeAddresses,

--- a/app/src/db/projects.ts
+++ b/app/src/db/projects.ts
@@ -1916,6 +1916,12 @@ export async function getPublicProject({ projectId }: { projectId: string }) {
         contracts: true,
         repos: true,
         funding: true,
+        rewards: {
+          select: {
+            roundId: true,
+            amount: true,
+          },
+        },
         organization: {
           select: {
             organization: {
@@ -1998,6 +2004,12 @@ export async function getPublicProject({ projectId }: { projectId: string }) {
 
   return {
     ...project,
+    devToolingRewards: project.rewards
+      ?.filter((reward) => reward.roundId === "7")
+      .reduce((acc, reward) => acc + Number(reward.amount), 0),
+    onchainBuildersRewards: project.rewards
+      ?.filter((reward) => reward.roundId === "8")
+      .reduce((acc, reward) => acc + Number(reward.amount), 0),
     devToolingApplication,
     onchainBuildersApplication,
     contributors: deduppedUsers,


### PR DESCRIPTION
Description:
Use project reward amounts on project profile page instead of data consumed from OSO Json files