### PR TITLE
Fix #800: Display "+Add" Button Only After Input in Organization Form

### DIFF
--- a/app/src/components/organizations/MakeOrganizationForm.tsx
+++ b/app/src/components/organizations/MakeOrganizationForm.tsx
@@ -94,6 +94,8 @@ export default function MakeOrganizationForm({
     },
   })
 
+  const formValues = form.watch();
+
   const { fields: websiteFields, append: addWebsiteField } = useFieldArray({
     control: form.control,
     name: "website",
@@ -176,6 +178,16 @@ export default function MakeOrganizationForm({
     setIsShowingRemove(null)
   }
 
+  // CHANGE: Add helper functions to check if the last field has a value
+  const shouldShowWebsiteAdd = () => {
+    const websites = formValues.website;
+    return websites[websites.length - 1]?.value.trim() !== '';
+  };
+
+  const shouldShowFarcasterAdd = () => {
+    const farcasters = formValues.farcaster;
+    return farcasters[farcasters.length - 1]?.value.trim() !== '';
+  };
   const onSubmit = () => async (values: z.infer<typeof formSchema>) => {
     setIsSaving(true)
 
@@ -485,14 +497,17 @@ export default function MakeOrganizationForm({
                 )}
               />
             ))}
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => addWebsiteField({ value: "" })}
-              leftIcon={<Plus size={16} />}
-            >
-              Add
-            </Button>
+            {/* Only show Add button when the last website field has a value */}
+            {shouldShowWebsiteAdd() && (
+              <Button
+                 type="button"
+                 variant="secondary"
+                 onClick={() => addWebsiteField({ value: "" })}
+                 leftIcon={<Plus size={16} />}
+               >
+                 Add
+              </Button>
+             )}
           </div>
 
           <div className="flex flex-col gap-1.5">
@@ -514,14 +529,17 @@ export default function MakeOrganizationForm({
                 )}
               />
             ))}
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => addFarcasterField({ value: "" })}
-              leftIcon={<Plus size={16} />}
-            >
-              Add
-            </Button>
+            {/* Only show Add button when the last Farcaster field has a value */}
+            {shouldShowFarcasterAdd() && (
+              <Button
+                 type="button"
+                 variant="secondary"
+                 onClick={() => addFarcasterField({ value: "" })}
+                 leftIcon={<Plus size={16} />}
+               >
+                 Add
+              </Button>
+             )}
           </div>
 
           <FormField


### PR DESCRIPTION
This pull request addresses the issue #800 , where the "+Add" button was visible before any initial link was input in the Organization settings form. As said in the issue this could lead to user confusion, as they might think they need to click "+Add" to save the link they've input. The changes ensure that the "+Add" button only appears after a link is input, aligning the behavior with the Project Settings form.

**Changes Made:**
- Added helper functions `shouldShowWebsiteAdd` and `shouldShowFarcasterAdd` to determine the visibility of the "+Add" button based on whether the last field has content.
- Updated the rendering logic for the "+Add" buttons in the form to utilize these helper functions, ensuring they only appear when appropriate.

**Impact:**
- Improves user experience by reducing confusion in the Organization settings form.
- Ensures consistency across different settings forms within the application.

**Testing:**
- Manually tested the form to ensure the "+Add" button appears only after a link is input for both website and farcaster fields.

**Related Issues:**
- Resolves the issue of premature "+Add" button visibility in the Organization settings form.