### PR TITLE
Persona CRON speedup

### DIFF
--- a/app/src/app/api/cron/persona/route.ts
+++ b/app/src/app/api/cron/persona/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest } from "next/server"
 
-import { processPersonaCases, processPersonaInquiries } from "@/lib/actions/kyc"
 import { withCronObservability } from "@/lib/cron"
-import { getPersonaCases, getPersonaInquiries } from "@/lib/persona"
+import {
+  getAndProcessPersonaCases,
+  getAndProcessPersonaInquiries,
+} from "@/lib/persona"
 
 export const maxDuration = 900
 export const dynamic = "force-dynamic"
@@ -11,22 +13,9 @@ export const revalidate = 0
 const MONITOR_SLUG = "cron-persona"
 
 async function handlePersonaCron(request: NextRequest) {
-  const cases = getPersonaCases()
-  const inquiries = getPersonaInquiries()
-
   await Promise.all([
-    (async () => {
-      for await (const batch of cases) {
-        // This drops the batch from memory after processing
-        await processPersonaCases(batch)
-      }
-    })(),
-    (async () => {
-      for await (const batch of inquiries) {
-        // This drops the batch from memory after processing
-        await processPersonaInquiries(batch)
-      }
-    })(),
+    getAndProcessPersonaCases(),
+    getAndProcessPersonaInquiries(),
   ])
 
   return Response.json({ status: "Persona cases and inquiries processed" })

--- a/app/src/app/api/cron/persona/route.ts
+++ b/app/src/app/api/cron/persona/route.ts
@@ -23,5 +23,5 @@ async function handlePersonaCron(request: NextRequest) {
 
 export const GET = withCronObservability(handlePersonaCron, {
   monitorSlug: MONITOR_SLUG,
-  requireAuth: false,
+  requireAuth: true,
 })

--- a/app/src/app/api/cron/persona/route.ts
+++ b/app/src/app/api/cron/persona/route.ts
@@ -23,5 +23,5 @@ async function handlePersonaCron(request: NextRequest) {
 
 export const GET = withCronObservability(handlePersonaCron, {
   monitorSlug: MONITOR_SLUG,
-  requireAuth: true,
+  requireAuth: false,
 })

--- a/app/src/lib/persona.ts
+++ b/app/src/lib/persona.ts
@@ -1,3 +1,5 @@
+import { processPersonaCases, processPersonaInquiries } from "./actions/kyc"
+
 const PERSONA_API_URL = "https://app.withpersona.com"
 
 export const inquiryStatusMap = {
@@ -123,10 +125,23 @@ async function* fetchGenerator<T>(
   } while (currentUrl)
 }
 
-export const getPersonaCases = () => {
-  return fetchGenerator<PersonaCase>(personaClient, "getCases")
+export const getAndProcessPersonaCases = () => {
+  return processPaginatedData(
+    () => fetchGenerator<PersonaCase>(personaClient, "getCases"),
+    processPersonaCases,
+  )
 }
 
-export const getPersonaInquiries = () => {
-  return fetchGenerator<PersonaInquiry>(personaClient, "getInquiries")
+export const getAndProcessPersonaInquiries = () => {
+  return processPaginatedData(
+    () => fetchGenerator<PersonaInquiry>(personaClient, "getInquiries"),
+    processPersonaInquiries,
+  )
+}
+
+async function processPaginatedData<T>(
+  fetchPage: () => AsyncGenerator<T[]>,
+  processBatch: (items: T[]) => Promise<void>,
+) {
+  return Promise.all(await Array.fromAsync(fetchPage(), processBatch))
 }

--- a/app/src/lib/persona.ts
+++ b/app/src/lib/persona.ts
@@ -143,5 +143,11 @@ async function processPaginatedData<T>(
   fetchPage: () => AsyncGenerator<T[]>,
   processBatch: (items: T[]) => Promise<void>,
 ) {
-  return Promise.all(await Array.fromAsync(fetchPage(), processBatch))
+  const processingPromises: Promise<void>[] = []
+
+  for await (const batch of fetchPage()) {
+    processingPromises.push(processBatch([...batch]))
+  }
+
+  return Promise.all(processingPromises)
 }


### PR DESCRIPTION
This PR speeds up Persona inquiries & cases processing by parallelizing processing at expense of increased memory consumption. 
Before: each batch is processed one at a time. Once processed, cache is cleared
After: each batch is processed in parallel with other batches. Once processed, cache is cleared. Memory consumption is significantly higher due to parallel processing. 

Batch size `~12KB`
Next memory limit: `3009 MB`

We'll hit memory limit at `~250K` batches. Realistically, there're will be way less than `100` batches processing simultaneously at any given moment -- so we're well within the limits