### PR TITLE
User profiles show projects that don't have project-profiles

### DIFF
--- a/app/src/components/profile/public/ProjectWithLink.tsx
+++ b/app/src/components/profile/public/ProjectWithLink.tsx
@@ -4,44 +4,28 @@ import TrackedExtendedLink from "@/components/common/TrackedExtendedLink"
 import { ProjectWithDetailsLite } from "@/lib/types"
 
 function ProjectWithLink({ project }: { project: ProjectWithDetailsLite }) {
+  if (project.applications.length === 0) return null
+
   return (
     <div className="flex items-center space-x-2">
-      {project.applications.length > 0 ? (
-        <TrackedExtendedLink
-          text={project.name}
-          href={`/project/${project.id}`}
-          eventName="Link Click"
-          eventData={{
-            projectId: project.id,
-            source: "Profile",
-            linkName: "Project",
-          }}
-          subtext={
-            project.rewards.length
-              ? `Rewarded in Retro Funding ${project.rewards
-                  .map((reward) => reward.roundId)
-                  .join(", ")}`
-              : undefined
-          }
-          icon={
-            project.thumbnailUrl ? (
-              <Image
-                src={project.thumbnailUrl ?? ""}
-                alt={project.name}
-                width={32}
-                height={32}
-                className="rounded-full object-cover"
-              />
-            ) : (
-              <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center">
-                <span>{project.name.charAt(0)}</span>
-              </div>
-            )
-          }
-        />
-      ) : (
-        <>
-          {project.thumbnailUrl ? (
+      <TrackedExtendedLink
+        text={project.name}
+        href={`/project/${project.id}`}
+        eventName="Link Click"
+        eventData={{
+          projectId: project.id,
+          source: "Profile",
+          linkName: "Project",
+        }}
+        subtext={
+          project.rewards.length
+            ? `Rewarded in Retro Funding ${project.rewards
+                .map((reward) => reward.roundId)
+                .join(", ")}`
+            : undefined
+        }
+        icon={
+          project.thumbnailUrl ? (
             <Image
               src={project.thumbnailUrl ?? ""}
               alt={project.name}
@@ -53,21 +37,9 @@ function ProjectWithLink({ project }: { project: ProjectWithDetailsLite }) {
             <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center">
               <span>{project.name.charAt(0)}</span>
             </div>
-          )}
-          <span>
-            {project.name.length > 20
-              ? `${project.name.slice(0, 20)}...`
-              : project.name}
-          </span>
-          <Image
-            src="/assets/icons/arrow-up-right.svg"
-            width={10}
-            height={10}
-            alt="External link"
-            className="ml-1 opacity-0 group-hover:opacity-100 transition-opacity"
-          />
-        </>
-      )}
+          )
+        }
+      />
     </div>
   )
 }


### PR DESCRIPTION
Issue: https://github.com/voteagora/op-atlas/issues/844

There is an open question here: I am guessing # 1 but feels worth it to check before merging

Should we hide the project from the profile if `project.applications.length === 0` (What this PR is currently doing)

OR

Still link to the project id anyway?