### PR TITLE
Correct etherscan network

### DIFF
--- a/app/src/components/common/chain.ts
+++ b/app/src/components/common/chain.ts
@@ -21,10 +21,11 @@ export const polynomial = {
   id: 8008,
 } as Chain
 
-export const CHAIN_INFO: { [chainId: string]: { logo: string; name: string } } =
-  {
-    [arenaZ.id.toString()]: {
-      logo: "/assets/chain-logos/arenaZ.png",
+export const CHAIN_INFO: {
+  [chainId: string]: { logo: string; name: string; blockExplorer?: string }
+} = {
+  [arenaZ.id.toString()]: {
+    logo: "/assets/chain-logos/arenaZ.png",
       name: "ArenaZ",
     },
     [bob.id.toString()]: {
@@ -34,10 +35,12 @@ export const CHAIN_INFO: { [chainId: string]: { logo: string; name: string } } =
     [base.id.toString()]: {
       logo: "/assets/chain-logos/base.png",
       name: "Base",
+      blockExplorer: base.blockExplorers.default.url,
     },
     [ethernity.id.toString()]: {
       logo: "/assets/chain-logos/ethernity.jpg",
       name: "Ethernity",
+      blockExplorer: ethernity.blockExplorers.default.url,
     },
     [ink.id.toString()]: {
       logo: "/assets/chain-logos/ink.jpg",
@@ -58,10 +61,12 @@ export const CHAIN_INFO: { [chainId: string]: { logo: string; name: string } } =
     [mode.id.toString()]: {
       logo: "/assets/chain-logos/mode.png",
       name: "Mode",
+      blockExplorer: mode.blockExplorers.default.url,
     },
     [optimism.id.toString()]: {
       logo: "/assets/chain-logos/optimism.svg",
       name: "OP Mainnet",
+      blockExplorer: optimism.blockExplorers.default.url,
     },
     [polynomial.id.toString()]: {
       logo: "/assets/chain-logos/polynomial.png",
@@ -90,10 +95,12 @@ export const CHAIN_INFO: { [chainId: string]: { logo: string; name: string } } =
     [unichain.id.toString()]: {
       logo: "/assets/chain-logos/unichain.jpg",
       name: "Unichain",
+      blockExplorer: unichain.blockExplorers.default.url,
     },
     [worldchain.id.toString()]: {
       logo: "/assets/chain-logos/worldchain.png",
       name: "Worldchain",
+      blockExplorer: worldchain.blockExplorers.default.url,
     },
     [zora.id.toString()]: {
       logo: "/assets/chain-logos/zora.png",

--- a/app/src/components/common/chain.ts
+++ b/app/src/components/common/chain.ts
@@ -21,6 +21,8 @@ export const polynomial = {
   id: 8008,
 } as Chain
 
+// Block explorer is defined just for chains using Etherscan or Routescan.
+// Blockscout doesn't support the /verifiedSignatures (or similar) page we use.
 export const CHAIN_INFO: {
   [chainId: string]: { logo: string; name: string; blockExplorer?: string }
 } = {

--- a/app/src/components/projects/contracts/VerifyAddressDialog.tsx
+++ b/app/src/components/projects/contracts/VerifyAddressDialog.tsx
@@ -15,6 +15,7 @@ import { verifyDeployer } from "@/lib/actions/contracts"
 import { getMessage } from "@/lib/utils/contracts"
 
 import { ChainSelector } from "./ChainSelector"
+import { CHAIN_INFO } from "@/components/common/chain"
 
 const defaultSelectedChain = 10
 
@@ -49,6 +50,12 @@ export function VerifyAddressDialog({
   const [selectedChain, setSelectedChain] =
     useState<number>(defaultSelectedChain)
 
+  const [chainInfo, setChainInfo] = useState<{
+    logo: string
+    name: string
+    blockExplorer?: string
+  }>(CHAIN_INFO[selectedChain.toString()])
+
   const onConfirmSignature = async () => {
     try {
       setLoading(true)
@@ -81,6 +88,13 @@ export function VerifyAddressDialog({
 
   async function onChainChange(value: string) {
     setSelectedChain(parseInt(value))
+    const chainInfo = CHAIN_INFO[value]
+    const chainInfoHasBlockExplorer = chainInfo?.blockExplorer
+    setChainInfo(
+      chainInfoHasBlockExplorer
+        ? chainInfo
+        : CHAIN_INFO[defaultSelectedChain.toString()],
+    )
   }
 
   return (
@@ -99,7 +113,7 @@ export function VerifyAddressDialog({
                   <br />
                   You can{" "}
                   <ExternalLink
-                    href="https://optimistic.etherscan.io/verifiedSignatures"
+                    href={`${chainInfo.blockExplorer}/verifiedSignatures`}
                     className="underline"
                   >
                     use Etherscan


### PR DESCRIPTION
Issue: https://github.com/voteagora/op-atlas/issues/736

Fixed only for chains using Etherscan or Routescan. Blockscout doesn't support the /verifiedSignatures (or similar) page we use.

Looked for an alternative/similar solution in Blockscout and couldn't find any.