### PR TITLE
Add OffChainVote object to prisma model

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -744,15 +744,15 @@ model OffChainVote {
 
   transactionHash String?    // Hash of the transaction that created the vote
   
-  // Optional relations to existing models
-  userId          String?
-  user            User?      @relation(fields: [userId], references: [id])
+  citizenId          String
+  citizen            Citizen  @relation(fields: [citizenId], references: [id])
+
 
   createdAt       DateTime   @default(now())
   updatedAt       DateTime   @updatedAt
 
   @@index([voterAddress])
   @@index([proposalId])
-  @@index([userId])
+  @@index([citizenId])
   @@index([transactionHash])
 }

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -508,6 +508,12 @@ enum KYCStatus {
   REJECTED
 }
 
+enum citizenCategory {
+  CHAIN
+  PROJECT
+  USER
+}
+
 model ContactEmailTags {
   id        String @id @default(uuid())
   email     String @unique
@@ -746,7 +752,7 @@ model OffChainVote {
   
   citizenId          String
   citizen            Citizen  @relation(fields: [citizenId], references: [id])
-
+  citizenCategory    citizenCategory @default(CHAIN)
 
   createdAt       DateTime   @default(now())
   updatedAt       DateTime   @updatedAt
@@ -756,3 +762,4 @@ model OffChainVote {
   @@index([citizenId])
   @@index([transactionHash])
 }
+

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -738,7 +738,10 @@ model OffChainVote {
   id              String     @id @default(uuid())
   voterAddress    String     // Ethereum address of the voter
   proposalId      String     // ID of the proposal being voted on
-  choice          Json       // JSON blob containing vote choice details
+  vote            Json       // For standard proposals, this is an array of choices, 
+                             // using strings for the values.
+                             // e.g. ["1"], where "0", "1", "2" are for, against, abstain
+
   attestationId   String     // EAS attestation ID
   transactionHash String?    // Hash of the transaction that created the vote
   

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -265,7 +265,6 @@ model Project {
   
   sourceProjects ProjectOSOAtlasRelatedProjects[] @relation("sourceProject")
   targetProjects ProjectOSOAtlasRelatedProjects[] @relation("targetProject")
-  votes         OffChainVote[]
 
   @@index([deletedAt, createdAt])
   @@index([deletedAt])

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -735,14 +735,13 @@ model ProjectOSOAtlasRelatedProjects {
 }
 
 model OffChainVote {
-  id              String     @id @default(uuid())
+  attestationId   String     @id  // EAS attestation ID as primary key
   voterAddress    String     // Ethereum address of the voter
   proposalId      String     // ID of the proposal being voted on
   vote            Json       // For standard proposals, this is an array of choices, 
                              // using strings for the values.
                              // e.g. ["1"], where "0", "1", "2" are for, against, abstain
 
-  attestationId   String     // EAS attestation ID
   transactionHash String?    // Hash of the transaction that created the vote
   
   // Optional relations to existing models
@@ -755,6 +754,5 @@ model OffChainVote {
   @@index([voterAddress])
   @@index([proposalId])
   @@index([userId])
-  @@index([attestationId])
   @@index([transactionHash])
 }

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -265,6 +265,7 @@ model Project {
   
   sourceProjects ProjectOSOAtlasRelatedProjects[] @relation("sourceProject")
   targetProjects ProjectOSOAtlasRelatedProjects[] @relation("targetProject")
+  votes         OffChainVote[]
 
   @@index([deletedAt, createdAt])
   @@index([deletedAt])
@@ -732,4 +733,27 @@ model ProjectOSOAtlasRelatedProjects {
   @@index([relatedProjectId])
 
   @@unique([projectId, tranche, relatedProjectId])
+}
+
+model OffChainVote {
+  id              String     @id @default(uuid())
+  voterAddress    String     // Ethereum address of the voter
+  proposalId      String     // ID of the proposal being voted on
+  choice          Json       // JSON blob containing vote choice details
+  attestationId   String     // EAS attestation ID
+  transactionHash String?    // Hash of the transaction that created the vote
+  
+  // Optional relations to existing models
+  userId          String?
+  user            User?      @relation(fields: [userId], references: [id])
+
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+  deletedAt       DateTime?
+
+  @@index([voterAddress])
+  @@index([proposalId])
+  @@index([userId])
+  @@index([attestationId])
+  @@index([transactionHash])
 }

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -751,7 +751,6 @@ model OffChainVote {
 
   createdAt       DateTime   @default(now())
   updatedAt       DateTime   @updatedAt
-  deletedAt       DateTime?
 
   @@index([voterAddress])
   @@index([proposalId])


### PR DESCRIPTION
This PR sets up a table in the atlas DB for recording off-chain votes, directly to the DB.

A future PR will write to this table, saving attestations to the chain and to this table, atomically -- reducing the dependency and latency from indexing.