### PR TITLE
Topbar sign in button needs polish

### DIFF
--- a/app/src/components/common/Account.tsx
+++ b/app/src/components/common/Account.tsx
@@ -228,7 +228,7 @@ export const Account = () => {
     return (
       <button
         type="button"
-        className={`cursor-pointer text-white rounded-md px-4 py-2 flex items-center justify-center w-24 h-10 ${
+        className={`cursor-pointer text-sm text-primary-foreground leading-5 rounded-md px-4 py-2.5 flex items-center justify-center h-10 ${
           isLoggingIn.current ? "bg-gray-300" : "bg-brand-primary"
         }`}
         onClick={privyLogin}


### PR DESCRIPTION
#Closes #1035

**Changes:**
- updated text size to 14px with 20px line-height and primary-foreground color
- updated to py-2.5 (10px top-bottom) while keeping px-4 (16px left-right)
- removed fixed width constraint to allow natural button sizing based on content and padding
- height: kept h-10 (40px) as specified

The button should now appear at the proper default size with the correct text styling and spacing as specified in your requirements