### PR TITLE
fix: add grant address organization

### DIFF
--- a/app/src/components/projects/rewards/AddGrantDeliveryAddressForm.tsx
+++ b/app/src/components/projects/rewards/AddGrantDeliveryAddressForm.tsx
@@ -29,7 +29,7 @@ export default function AddGrantDeliveryAddressForm({
   const { organizationId, projectId } = useParams()
   const queryClient = useQueryClient()
 
-  const { mutate: deleteProjectKYCTeam } = useMutation({
+  const { mutate: deleteProjectKYCTeam, isPending: isDeleting } = useMutation({
     mutationFn: async () => {
       if (!organizationId) {
         await deleteProjectKYCTeamAction({
@@ -90,10 +90,26 @@ export default function AddGrantDeliveryAddressForm({
     deleteProjectKYCTeam()
   }
 
+  const onStartOver = () => {
+    if (kycTeam?.id) {
+      deleteProjectKYCTeam()
+    }
+  }
+
   return (
     <div className="p-6 border rounded-xl space-y-6 w-full">
       {!allTeamMembersVerified && (
-        <h4 className="font-semibold text-base">Add an address</h4>
+        <div className="flex justify-between items-center">
+          <h4 className="font-semibold text-base">Add an address</h4>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onStartOver}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            Start over
+          </Button>
+        </div>
       )}
       {allTeamMembersVerified ? (
         <CompletedGrantDeliveryForm
@@ -153,16 +169,35 @@ export default function AddGrantDeliveryAddressForm({
                       </div>
                     )}
                   </div>
-                  <Button
-                    className="mt-4"
-                    variant="secondary"
-                    onClick={onDeleteProjectKYCTeam}
-                  >
-                    Start over
-                  </Button>
+                  <div className="flex gap-2 mt-4">
+                    <Button
+                      variant="secondary"
+                      onClick={onDeleteProjectKYCTeam}
+                    >
+                      Start over
+                    </Button>
+                  </div>
                 </>
               ) : (
-                <DeliveryAddressVerificationForm />
+                <>
+                  <DeliveryAddressVerificationForm />
+                  <div className="mt-4 pt-4 border-t">
+                    <Button
+                      variant="outline"
+                      onClick={onStartOver}
+                      disabled={isDeleting}
+                    >
+                      {isDeleting ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Deleting...
+                        </>
+                      ) : (
+                        "Start over"
+                      )}
+                    </Button>
+                  </div>
+                </>
               ),
             },
             {
@@ -275,7 +310,7 @@ export default function AddGrantDeliveryAddressForm({
                   )}
                   <div className="space-y-4">
                     <div className="text-sm text-secondary-foreground font-normal">
-                      Is something missing or incorrect? You’ll need to{" "}
+                      Is somethi ng missing or incorrect? You&apos;ll need to{" "}
                       <Link
                         className="underline hover:opacity-80 transition-colors duration-300"
                         href={`https://superchain.typeform.com/to/Pq0c7jYJ#l2_address=${kycTeam?.walletAddress}&kyc_team_id=${kycTeam?.id}`}

--- a/app/src/components/projects/rewards/AddGrantDeliveryAddressForm.tsx
+++ b/app/src/components/projects/rewards/AddGrantDeliveryAddressForm.tsx
@@ -80,7 +80,6 @@ export default function AddGrantDeliveryAddressForm({
       values.add("item-2")
     }
 
-    // Convert to array and return
     return Array.from(values)
   }, [kycTeam, allTeamMembersVerified])
 

--- a/app/src/components/projects/rewards/AddGrantDeliveryAddressForm.tsx
+++ b/app/src/components/projects/rewards/AddGrantDeliveryAddressForm.tsx
@@ -309,7 +309,7 @@ export default function AddGrantDeliveryAddressForm({
                   )}
                   <div className="space-y-4">
                     <div className="text-sm text-secondary-foreground font-normal">
-                      Is somethi ng missing or incorrect? You&apos;ll need to{" "}
+                      Is something missing or incorrect? You&apos;ll need to{" "}
                       <Link
                         className="underline hover:opacity-80 transition-colors duration-300"
                         href={`https://superchain.typeform.com/to/Pq0c7jYJ#l2_address=${kycTeam?.walletAddress}&kyc_team_id=${kycTeam?.id}`}

--- a/app/src/components/projects/rewards/DeliveryAddressVerificationForm.tsx
+++ b/app/src/components/projects/rewards/DeliveryAddressVerificationForm.tsx
@@ -3,7 +3,10 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import Link from "next/link"
 import { useParams } from "next/navigation"
+import { useState } from "react"
 import { useForm } from "react-hook-form"
+import { toast } from "sonner"
+import { isAddress } from "viem"
 import { z } from "zod"
 
 import { Button } from "@/components/common/Button"
@@ -15,11 +18,20 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
 } from "@/components/ui/form"
+import { checkWalletAddressExistsForOrganizationAction } from "@/lib/actions/organizations"
+import { checkWalletAddressExistsAction } from "@/lib/actions/projects"
 import { useAppDialogs } from "@/providers/DialogProvider"
 
 const FormSchema = z.object({
-  address: z.string().nonempty(),
+  address: z
+    .string()
+    .nonempty("Address is required")
+    .refine(
+      (value) => value === "" || isAddress(value),
+      "Please enter a valid Ethereum address",
+    ),
   confirmIsOpMainnet: z.boolean().default(false),
   confirmCanMakeContractCalls: z.boolean().default(false),
   pledgeToChooseDelegate: z.boolean().default(false),
@@ -27,7 +39,7 @@ const FormSchema = z.object({
 
 export default function DeliveryAddressVerificationForm() {
   const { setOpenDialog, setData } = useAppDialogs()
-
+  const [isChecking, setIsChecking] = useState(false)
   const { organizationId } = useParams()
 
   const form = useForm<z.infer<typeof FormSchema>>({
@@ -46,29 +58,52 @@ export default function DeliveryAddressVerificationForm() {
     form.watch("pledgeToChooseDelegate") &&
     form.watch("address")
 
-  const onSubmit = (data: z.infer<typeof FormSchema>) => {
-    setData({
-      address: data.address,
-      organizationId: organizationId as string,
-    })
-    setOpenDialog("verify_grant_delivery_address")
+  const onSubmit = async (data: z.infer<typeof FormSchema>) => {
+    setIsChecking(true)
+
+    try {
+      const checkResult = organizationId
+        ? await checkWalletAddressExistsForOrganizationAction(data.address)
+        : await checkWalletAddressExistsAction(data.address)
+
+      if (checkResult.error) {
+        toast.error(checkResult.error)
+        setIsChecking(false)
+        return
+      }
+
+      if (checkResult.exists) {
+        form.setError("address", {
+          type: "manual",
+          message:
+            "This address is already in use by another KYC team. Please use a different address.",
+        })
+        setIsChecking(false)
+        return
+      }
+
+      setData({
+        address: data.address,
+        organizationId: organizationId as string,
+      })
+      setOpenDialog("verify_grant_delivery_address")
+    } catch (error) {
+      console.error("Error checking wallet address:", error)
+      toast.error("Error verifying the address. Please try again.")
+    } finally {
+      setIsChecking(false)
+    }
   }
 
   return (
     <Form {...form}>
-      <form
-        onSubmit={(e) => {
-          form.handleSubmit(onSubmit)(e)
-          form.reset()
-        }}
-        className="w-full space-y-4"
-      >
+      <form onSubmit={form.handleSubmit(onSubmit)} className="w-full space-y-4">
         <div className="w-full space-y-2">
           <FormField
             control={form.control}
             name="address"
             render={({ field }) => (
-              <FormItem className="flex items-center space-x-3">
+              <FormItem className="flex flex-col space-y-2">
                 <FormControl>
                   <Input
                     leftIcon="/assets/chain-logos/optimism.svg"
@@ -76,6 +111,7 @@ export default function DeliveryAddressVerificationForm() {
                     {...field}
                   />
                 </FormControl>
+                <FormMessage />
               </FormItem>
             )}
           />
@@ -138,9 +174,15 @@ export default function DeliveryAddressVerificationForm() {
             )}
           />
         </div>
-        <Button variant="primary" type="submit" disabled={!submitEnabled}>
-          Verify
-        </Button>
+        <div className="flex gap-2">
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={!submitEnabled || isChecking}
+          >
+            {isChecking ? "Verifying..." : "Verify"}
+          </Button>
+        </div>
       </form>
     </Form>
   )

--- a/app/src/components/projects/rewards/DeliveryAddressVerificationForm.tsx
+++ b/app/src/components/projects/rewards/DeliveryAddressVerificationForm.tsx
@@ -20,7 +20,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
-import { checkWalletAddressExistsForOrganizationAction } from "@/lib/actions/organizations"
 import { checkWalletAddressExistsAction } from "@/lib/actions/projects"
 import { useAppDialogs } from "@/providers/DialogProvider"
 
@@ -62,9 +61,7 @@ export default function DeliveryAddressVerificationForm() {
     setIsChecking(true)
 
     try {
-      const checkResult = organizationId
-        ? await checkWalletAddressExistsForOrganizationAction(data.address)
-        : await checkWalletAddressExistsAction(data.address)
+      const checkResult = await checkWalletAddressExistsAction(data.address)
 
       if (checkResult.error) {
         toast.error(checkResult.error)

--- a/app/src/db/kyc.ts
+++ b/app/src/db/kyc.ts
@@ -83,6 +83,34 @@ export async function getProjectKycTeam(projectId: string) {
   return project?.kycTeam ?? undefined
 }
 
+export async function checkWalletAddressExists(walletAddress: string) {
+  const existingKycTeam = await prisma.kYCTeam.findUnique({
+    where: {
+      walletAddress: walletAddress.toLowerCase(),
+      deletedAt: null,
+    },
+  })
+
+  return existingKycTeam !== null
+}
+
+export async function getKycTeamByWalletAddress(walletAddress: string) {
+  return await prisma.kYCTeam.findUnique({
+    where: {
+      walletAddress: walletAddress.toLowerCase(),
+      deletedAt: null,
+    },
+    include: {
+      team: {
+        include: {
+          users: true,
+        },
+      },
+      rewardStreams: true,
+    },
+  })
+}
+
 export async function deleteKycTeam({
   kycTeamId,
   hasActiveStream,

--- a/app/src/lib/actions/organizations.ts
+++ b/app/src/lib/actions/organizations.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache"
 
 import { auth } from "@/auth"
 import { deleteKycTeam } from "@/db/kyc"
+import { checkWalletAddressExists, getKycTeamByWalletAddress } from "@/db/kyc"
 import {
   addOrganizationMembers,
   createOrganization,
@@ -211,6 +212,36 @@ export const removeMemberFromOrganization = async (
   await removeOrganizationMember({ organizationId, userId })
   revalidatePath("/dashboard")
   revalidatePath("/profile", "layout")
+}
+
+export const checkWalletAddressExistsForOrganizationAction = async (
+  walletAddress: string,
+) => {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return {
+      error: "Unauthorized",
+    }
+  }
+
+  const exists = await checkWalletAddressExists(walletAddress)
+  return { exists }
+}
+
+export const getKycTeamByWalletAddressForOrganizationAction = async (
+  walletAddress: string,
+) => {
+  const session = await auth()
+
+  if (!session?.user?.id) {
+    return {
+      error: "Unauthorized",
+    }
+  }
+
+  const kycTeam = await getKycTeamByWalletAddress(walletAddress)
+  return kycTeam
 }
 
 export const createOrganizationKycTeamAction = async ({

--- a/app/src/lib/actions/projects.ts
+++ b/app/src/lib/actions/projects.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache"
 
 import { auth } from "@/auth"
 import { deleteKycTeam } from "@/db/kyc"
+import { checkWalletAddressExists, getKycTeamByWalletAddress } from "@/db/kyc"
 import {
   addTeamMembers,
   createProject,
@@ -565,4 +566,34 @@ export const getPublicProjectAction = async ({
   if (!rawProject) return null
 
   return rawProject
+}
+
+export const checkWalletAddressExistsAction = async (walletAddress: string) => {
+  const session = await auth()
+  const userId = session?.user?.id
+
+  if (!userId) {
+    return {
+      error: "Unauthorized",
+    }
+  }
+
+  const exists = await checkWalletAddressExists(walletAddress)
+  return { exists }
+}
+
+export const getKycTeamByWalletAddressAction = async (
+  walletAddress: string,
+) => {
+  const session = await auth()
+  const userId = session?.user?.id
+
+  if (!userId) {
+    return {
+      error: "Unauthorized",
+    }
+  }
+
+  const kycTeam = await getKycTeamByWalletAddress(walletAddress)
+  return kycTeam
 }


### PR DESCRIPTION
## Description
This PR fixes Grant Delivery Address Flow Issues

### Problem
- **Start Over button was non-functional** - existed but had empty implementation
- **Address validation occurred too late** - after signature step, causing addresses to disappear
- **Poor error handling** - confusing "already KYC'd" messages and form data loss
- **Addresses became unusable** - validation considered soft-deleted KYC teams

### Solution
- **Implement functional Start Over button** - properly deletes KYC teams and resets process
- ** Add early address validation** - check availability before signature step
- ** Preserve form data on errors** - maintain user input when validation fails
- ** Improve error messages** - clear, actionable feedback for duplicate addresses
- ** Fix validation logic** - only consider active KYC teams (`deletedAt: null`)

### Changes
- **Backend**: Add `checkWalletAddressExists` functions for validation
- **Frontend**: Early validation in `DeliveryAddressVerificationForm`
- **UX**: Functional Start Over buttons with proper state management
- **Error handling**: Clear messages and data preservation

### Testing
- [x] Start Over button works correctly
- [x]  Address validation prevents duplicate entries
- [x]  Form data preserved on validation errors
- [x]  Clear error messages for users
- [x]  Proper soft-delete handling

