### PR TITLE
Fix: Handle form validation based on noRepos checkbox state

### DIFF
--- a/app/src/components/projects/repos/schema.ts
+++ b/app/src/components/projects/repos/schema.ts
@@ -1,7 +1,6 @@
 import { z } from "zod"
 
-export const GithubRepoSchema = z.object({
-  url: z.string().url(),
+const GithubRepoBaseSchema = z.object({
   verified: z.boolean().default(false),
   openSource: z.boolean().default(false),
   containsContracts: z.boolean().default(false),
@@ -11,16 +10,35 @@ export const GithubRepoSchema = z.object({
   description: z.string().optional(),
 })
 
+// Strict schema with URL validation for actual repos
+export const GithubRepoSchema = GithubRepoBaseSchema.extend({
+  url: z.string().url(),
+})
+
+// Relaxed schema for form state when noRepos is true
+const GithubRepoFormSchema = GithubRepoBaseSchema.extend({
+  url: z.string(),
+})
+
 export type GithubRepo = z.infer<typeof GithubRepoSchema>
 
 export const LinkSchema = z.object({
-  url: z.string().url(),
+  url: z.string().url().or(z.literal("")),
   name: z.string(),
   description: z.string(),
 })
 
-export const ReposFormSchema = z.object({
-  noRepos: z.boolean(),
-  githubRepos: z.array(GithubRepoSchema),
-  links: z.array(LinkSchema),
-})
+export const ReposFormSchema = z.discriminatedUnion("noRepos", [
+  // When noRepos is true, allow empty/invalid URLs
+  z.object({
+    noRepos: z.literal(true),
+    githubRepos: z.array(GithubRepoFormSchema),
+    links: z.array(LinkSchema),
+  }),
+  // When noRepos is false, enforce proper validation
+  z.object({
+    noRepos: z.literal(false),
+    githubRepos: z.array(GithubRepoSchema),
+    links: z.array(LinkSchema),
+  }),
+])


### PR DESCRIPTION
Use discriminated union to conditionally validate GitHub repo URLs only when repos are expected.
 * Create separate schemas for strict (with URL validation) and relaxed (form state) validation
 * Allow empty URLs in links since they're filtered on submit
 * Use discriminated union to switch validation rules based on noRepos value