### PR TITLE
fix: show all user projects including those in organizations

### DIFF
--- a/app/src/db/projects.ts
+++ b/app/src/db/projects.ts
@@ -345,17 +345,16 @@ async function getAllPublishedUserProjectsFn({
           )
         ) FILTER (WHERE fr."id" IS NOT NULL), '[]') as "rewards"
       FROM "Project" p
-      LEFT JOIN "UserProjects" up ON p."id" = up."projectId" 
+      JOIN "UserProjects" up ON p."id" = up."projectId" 
         AND up."deletedAt" IS NULL
+        AND up."userId" = ${userId}
       LEFT JOIN "ProjectFunding" pf ON p."id" = pf."projectId"
       LEFT JOIN "ProjectSnapshot" ps ON p."id" = ps."projectId"
       LEFT JOIN "Application" a ON p."id" = a."projectId"
       LEFT JOIN "ProjectLinks" pl ON p."id" = pl."projectId"
       LEFT JOIN "FundingReward" fr ON p."id" = fr."projectId"
       LEFT JOIN "RewardClaim" rc ON fr."id" = rc."rewardId"
-      WHERE up."userId" = ${userId}
-        AND p."deletedAt" IS NULL
-        AND p."id" NOT IN (SELECT "projectId" FROM "ProjectOrganization")
+      WHERE p."deletedAt" IS NULL
       GROUP BY p."id"
     ),
     "org_projects" AS (


### PR DESCRIPTION
The getAllPublishedUserProjectsFn was filtering out projects that belonged to organizations, even when the user was a direct member of those projects. This caused projects to not appear in user profiles despite the user being a valid member.

The filter NOT IN (SELECT "projectId" FROM "ProjectOrganization") excluded ALL organizational projects, regardless of whether the user was a direct member or not.
