### PR TITLE
refactor: matching styles with design make organization dialog

### DIFF
--- a/app/src/components/organizations/CreateOrganizationDialog.tsx
+++ b/app/src/components/organizations/CreateOrganizationDialog.tsx
@@ -176,12 +176,15 @@ function CreateOrganizationDialog({ onOpenChange, open }: DialogProps<object>) {
               </FileUploadInput>
             </Button>
             <Button
-              onClick={() => onOpenChange(false)}
+              onClick={() => {
+                setIsDialogOpen(false)
+                setIsShowingAdd(true)
+              }}
               className="w-full !ml-0"
               type="button"
               variant="outline"
             >
-              Close
+              Skip
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
Changes the "Close" button to "Skip" in the organization creation modal to match the original Figma design. When clicked, the "Skip" button now continues to the next step (add team members) instead of closing the modal entirely.
