### PR TITLE
Garrett/1177 admins should be able to remove themselves from projects and orgs if there are other admins

### DIFF
--- a/app/src/components/organizations/MakeOrganizationForm.tsx
+++ b/app/src/components/organizations/MakeOrganizationForm.tsx
@@ -151,7 +151,15 @@ export default function MakeOrganizationForm({
 
   const handleToggleRole = async (selectedUser: User, role: TeamRole) => {
     if (organization) {
-      await setOrganizationMemberRole(organization.id, selectedUser.id, role)
+      const changeResult = await setOrganizationMemberRole(
+        organization.id,
+        selectedUser.id,
+        role,
+      )
+
+      if (changeResult?.error) {
+        toast.error(changeResult.error)
+      }
     } else {
       setTeam((prev) => {
         const updatedTeam = prev.map((item) => {

--- a/app/src/components/organizations/MakeOrganizationForm.tsx
+++ b/app/src/components/organizations/MakeOrganizationForm.tsx
@@ -333,7 +333,9 @@ export default function MakeOrganizationForm({
     }
   }, [organization?.team])
 
-  const canSubmit = form.formState.isValid && !form.formState.isSubmitting
+  const hasAdmin = team.some((member) => member.role === "admin")
+  const canSubmit =
+    form.formState.isValid && !form.formState.isSubmitting && hasAdmin
 
   return (
     <Form {...form}>
@@ -599,7 +601,7 @@ export default function MakeOrganizationForm({
           />
         </div>
 
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2">
           <Button
             disabled={!canSubmit || isSaving || !form.formState.isDirty}
             onClick={form.handleSubmit(onSubmit())}
@@ -608,6 +610,11 @@ export default function MakeOrganizationForm({
           >
             Save
           </Button>
+          {!hasAdmin && (
+            <p className="text-sm text-destructive">
+              At least one team member must have an admin role.
+            </p>
+          )}
         </div>
       </form>
 

--- a/app/src/lib/actions/organizations.ts
+++ b/app/src/lib/actions/organizations.ts
@@ -183,7 +183,7 @@ export const setOrganizationMemberRole = async (
 
   if (!teamHasAdmin) {
     return {
-      error: "At least 1 admin member must remain in the team",
+      error: "At least 1 member on the team must be an Admin",
     }
   }
 

--- a/app/src/lib/actions/organizations.ts
+++ b/app/src/lib/actions/organizations.ts
@@ -183,19 +183,18 @@ export const setOrganizationMemberRole = async (
 
 export const checkTeamHasAdminOtherThanUser = async ({
   organizationId,
+  userToRemove,
 }: {
   organizationId: string
+  userToRemove: string
 }) => {
   // At least one remaining member must be an admin
-
-  const session = await auth()
-
   const team = await getOrganizationTeam({ id: organizationId })
 
   const adminChecks = await Promise.all(
     team?.team.map(
       (member) =>
-        member.userId !== session?.user.id &&
+        member.userId !== userToRemove &&
         isUserAdminOfOrganization(member.userId, organizationId),
     ) ?? [],
   )
@@ -233,7 +232,10 @@ export const removeMemberFromOrganization = async (
   }
 
   // Team has admin other than the user
-  const teamHasAdmin = await checkTeamHasAdminOtherThanUser({ organizationId })
+  const teamHasAdmin = await checkTeamHasAdminOtherThanUser({
+    organizationId,
+    userToRemove: userId,
+  })
 
   if (!teamHasAdmin) {
     return {

--- a/app/src/lib/actions/organizations.ts
+++ b/app/src/lib/actions/organizations.ts
@@ -175,6 +175,18 @@ export const setOrganizationMemberRole = async (
     return isInvalid
   }
 
+  // Team has admin other than the user
+  const teamHasAdmin = await checkTeamHasAdminOtherThanUser({
+    organizationId,
+    userToRemove: userId,
+  })
+
+  if (!teamHasAdmin) {
+    return {
+      error: "At least 1 admin member must remain in the team",
+    }
+  }
+
   await updateOrganizationMemberRole({ organizationId, userId, role })
 
   revalidatePath("/dashboard")


### PR DESCRIPTION
You can now remove yourself from an organization, but it must have one other admin.

I used this check to also clean up a couple edge cases. 
- A user can no longer create an organization with no admins by changing themselves to a contributor.
- A user can no longer create a new organization without at least one admin.


https://www.loom.com/share/66b817f547624eb68c1483009df0e9dc?sid=46d0d3b7-beb0-4fe7-9a94-54434a050b3b