### PR TITLE
Added user_group to tracking for Citizen Voting Page View

### DIFF
--- a/app/src/components/proposals/proposalPage/VotingSidebar/VotingSidebar.tsx
+++ b/app/src/components/proposals/proposalPage/VotingSidebar/VotingSidebar.tsx
@@ -69,6 +69,7 @@ const VotingSidebar = ({ proposalData }: VotingSidebarProps) => {
           : session?.user?.id
           ? "not signed in"
           : "ineligible",
+        user_group: citizenEligibility?.type,
       })
       isTracked.current = true
     }


### PR DESCRIPTION
user_group was erroneously removed in a previous merge. Added back in to the `Citizen Voting Page View` mixpanel event