### PR TITLE
Fix: Remove enabling dates programmatically for rewards

### DIFF
--- a/app/src/app/project/[projectId]/components/Mission/DevToolingMission/index.tsx
+++ b/app/src/app/project/[projectId]/components/Mission/DevToolingMission/index.tsx
@@ -11,12 +11,13 @@ import { Accordion, AccordionItem } from "@/components/ui/accordion"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MONTHS } from "@/lib/oso/constants"
 import { DevToolingMissionProps } from "@/lib/oso/types"
-import { generateTrancheMonths } from "@/lib/oso/utils"
+import { REWARD_GENERATED_MONTHS } from "@/lib/oso/utils"
 import { formatNumber } from "@/lib/utils"
 
 import MetricCard from "./MetricCard"
 
-const DEV_TOOLING_MONTHS = generateTrancheMonths("2025-02-01")
+// Cant automatically generate months as the rewards can be processed after few days into the month
+const DEV_TOOLING_MONTHS = REWARD_GENERATED_MONTHS
 
 export default function DevToolingMission({
   data,

--- a/app/src/app/project/[projectId]/components/Mission/OnchainBuilderMission/index.tsx
+++ b/app/src/app/project/[projectId]/components/Mission/OnchainBuilderMission/index.tsx
@@ -16,14 +16,15 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MONTHS } from "@/lib/oso/constants"
 import { OnchainBuilderMissionProps } from "@/lib/oso/types"
-import { generateTrancheMonths } from "@/lib/oso/utils"
+import { REWARD_GENERATED_MONTHS } from "@/lib/oso/utils"
 import { formatNumber } from "@/lib/utils"
 
 import AlertContainer from "./AlertContainer"
 import MetricCard from "./MetricCard"
 import NotPassingEligibility from "./NotPassingEligibility"
 
-const ONCHAIN_BUILDER_MONTHS = generateTrancheMonths("2025-02-01")
+// Cant automatically generate months as the rewards can be processed after few days into the month
+const ONCHAIN_BUILDER_MONTHS = REWARD_GENERATED_MONTHS
 
 export default function OnchainBuilderMission({
   data,

--- a/app/src/lib/oso/utils.ts
+++ b/app/src/lib/oso/utils.ts
@@ -401,3 +401,12 @@ export const generateTrancheMonths = (startDate: string) => {
 
   return months
 }
+
+
+export const REWARD_GENERATED_MONTHS = {
+  1: "Feb",
+  2: "Mar",
+  3: "Apr",
+  4: "May",
+  5: "Jun",
+}


### PR DESCRIPTION
 * Use const with pre populated months for enabling months on project pages.
 
 Rewards are not generated on first of every month, enabling previous month on first of every month will cause inconsistencies, revert to hard coded Obj for rewarded months. 