### PR TITLE
Load dot env

### DIFF
--- a/app/codegen.ts
+++ b/app/codegen.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 import type { CodegenConfig } from "@graphql-codegen/cli"
 
 const config: CodegenConfig = {


### PR DESCRIPTION
This PR loads the .env file before graphql code-gen, allowing the script to pick up `OSO_AUTH_TOKEN` properly on our local.