### PR TITLE
Added function to help cast link to the proper social site should they use an @ symbol

### DIFF
--- a/app/src/components/common/SocialBadgeLink.tsx
+++ b/app/src/components/common/SocialBadgeLink.tsx
@@ -31,10 +31,22 @@ export default function SocialBadgeLink({
     })
   }
 
+  const normalizedLink = (href: string): string => {
+    switch (type) {
+      case "twitter":
+      case "X":
+        return `https://x.com/${href.slice(1)}`
+      case "farcaster":
+        return `https://farcaster.xyz/${href.slice(1)}`
+      default:
+        return href
+    }
+  }
+
   return (
     <div className="py-1 px-2.5 rounded-full bg-secondary text-sm font-medium flex items-center space-x-1">
       {icon}
-      <Link href={href} target={target} onClick={handleClick}>
+      <Link href={normalizedLink(href)} target={target} onClick={handleClick}>
         {text}
       </Link>
     </div>


### PR DESCRIPTION
adds a function that will attempt to cast @prepended usernames to the proper social site in SocialBadeLinks