### PR TITLE
OPAG-171-Set-Clear-titles-across-Atlas

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -11,6 +11,12 @@ import {
   getProjects,
 } from "@/lib/actions/projects"
 
+export const metadata = {
+  title: "Dashboard - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+}
+
 export default async function Page() {
   const session = await auth()
   const userId = session?.user?.id

--- a/app/src/app/governance/page.tsx
+++ b/app/src/app/governance/page.tsx
@@ -1,9 +1,15 @@
-"use server"
-
-import { getAllRoles } from "@/db/role"
 import { auth } from "@/auth"
 import ProposalsPage from "@/components/proposals/proposalsPage/ProposalsPage"
+import { getAllRoles } from "@/db/role"
+
 import RolesPage from "./roles/components/RolesPage"
+
+export const metadata = {
+  title: "Governance: Roles - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+  openGraph: { title: "Governance: Roles - OP Atlas" },
+}
 
 export default async function Page() {
   const roles = await getAllRoles()

--- a/app/src/app/governance/roles/[roleId]/apply/[applicationId]/page.tsx
+++ b/app/src/app/governance/roles/[roleId]/apply/[applicationId]/page.tsx
@@ -10,16 +10,14 @@ import { getRoleApplicationById, getRoleById } from "@/db/role"
 import { getUserById } from "@/db/users"
 import { formatMMMd } from "@/lib/utils/date"
 
-interface pageProps {
-  roleId: string
-  applicationId: string
+type PageProps = {
+  params: { roleId: string; applicationId: string }
+  searchParams?: { [key: string]: string | string[] | undefined }
 }
 
 export async function generateMetadata({
   params,
-}: {
-  params: pageProps
-}): Promise<Metadata> {
+}: PageProps): Promise<Metadata> {
   const role = await getRoleById(parseInt(params.roleId))
   return {
     ...sharedMetadata,
@@ -32,7 +30,7 @@ export async function generateMetadata({
     },
   }
 }
-export default async function Page(params: pageProps) {
+export default async function Page({ params }: PageProps) {
   const [role, application] = await Promise.all([
     getRoleById(parseInt(params.roleId)),
     getRoleApplicationById(parseInt(params.applicationId)),

--- a/app/src/app/governance/roles/[roleId]/apply/[applicationId]/page.tsx
+++ b/app/src/app/governance/roles/[roleId]/apply/[applicationId]/page.tsx
@@ -1,18 +1,38 @@
+import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { AnalyticsTracker } from "@/app/governance/roles/[roleId]/apply/[applicationId]/components/AnalyticsTracker"
 import { CopyForumTextButton } from "@/app/governance/roles/[roleId]/apply/[applicationId]/components/CopyForumTextButton"
+import { sharedMetadata } from "@/app/shared-metadata"
 import { UserAvatar } from "@/components/common/UserAvatar"
 import { getOrganization } from "@/db/organizations"
 import { getRoleApplicationById, getRoleById } from "@/db/role"
 import { getUserById } from "@/db/users"
 import { formatMMMd } from "@/lib/utils/date"
 
-export default async function Page({
+interface pageProps {
+  roleId: string
+  applicationId: string
+}
+
+export async function generateMetadata({
   params,
 }: {
-  params: { roleId: string; applicationId: string }
-}) {
+  params: pageProps
+}): Promise<Metadata> {
+  const role = await getRoleById(parseInt(params.roleId))
+  return {
+    ...sharedMetadata,
+    title: `Governance: ${role?.title ?? ""} | Application - OP Atlas`,
+    description: role?.description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title: `Governance: ${role?.title ?? ""} | Application - OP Atlas`,
+      description: role?.description?.slice(0, 240) || undefined,
+    },
+  }
+}
+export default async function Page(params: pageProps) {
   const [role, application] = await Promise.all([
     getRoleById(parseInt(params.roleId)),
     getRoleApplicationById(parseInt(params.applicationId)),

--- a/app/src/app/governance/roles/[roleId]/apply/page.tsx
+++ b/app/src/app/governance/roles/[roleId]/apply/page.tsx
@@ -16,6 +16,12 @@ import { getUserById } from "@/db/users"
 import { getUserOrganizations } from "@/lib/actions/organizations"
 import { formatMMMd } from "@/lib/utils/date"
 
+export const metadata = {
+  title: "Governance - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+}
+
 export default async function Page({ params }: { params: { roleId: string } }) {
   const session = await auth()
   const userId = session?.user?.id

--- a/app/src/app/governance/roles/[roleId]/page.tsx
+++ b/app/src/app/governance/roles/[roleId]/page.tsx
@@ -15,6 +15,26 @@ import {
 import { getRoleApplications, getRoleById } from "@/db/role"
 import { formatMMMd } from "@/lib/utils/date"
 import { RoleDates } from "./components/RoleDates"
+import { Metadata } from "next"
+import { sharedMetadata } from "@/app/shared-metadata"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { roleId: string }
+}): Promise<Metadata> {
+  const role = await getRoleById(parseInt(params.roleId))
+  return {
+    ...sharedMetadata,
+    title: `Governance: ${role?.title ?? ""} - OP Atlas`,
+    description: role?.description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title: `Governance: ${role?.title ?? ""} - OP Atlas`,
+      description: role?.description?.slice(0, 240) || undefined,
+    },
+  }
+}
 
 export default async function Page({ params }: { params: { roleId: string } }) {
   const role = await getRoleById(parseInt(params.roleId))

--- a/app/src/app/missions/[id]/application/page.tsx
+++ b/app/src/app/missions/[id]/application/page.tsx
@@ -1,9 +1,30 @@
+import { Metadata } from "next"
 import { notFound, redirect } from "next/navigation"
 import React from "react"
 
+import { sharedMetadata } from "@/app/shared-metadata"
+import { auth } from "@/auth"
 import { MissionApplication } from "@/components/missions/application/MissionApplication"
 import { MISSIONS } from "@/lib/MissionsAndRoundData"
-import { auth } from "@/auth"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string }
+}): Promise<Metadata> {
+  const mission = MISSIONS.find((page) => page.pageName === params.id)
+
+  return {
+    ...sharedMetadata,
+    title: `Retro Funding: ${mission?.name ?? ""} | Application - OP Atlas`,
+    description: mission?.ogDescription,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title: `Retro Funding: ${mission?.name ?? ""} | Application - OP Atlas`,
+      description: mission?.ogDescription,
+    },
+  }
+}
 
 export default async function MissionApplicationPage({
   params,

--- a/app/src/app/profile/connected-apps/page.tsx
+++ b/app/src/app/profile/connected-apps/page.tsx
@@ -1,11 +1,23 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
-import { Discord, Farcaster, Github, Optimism } from "@/components/icons/socials"
+import {
+  Discord,
+  Farcaster,
+  Github,
+  Optimism,
+} from "@/components/icons/socials"
 import { DiscordConnection } from "@/components/profile/DiscordConnection"
 import { FarcasterConnection } from "@/components/profile/FarcasterConnection"
 import { GithubConnection } from "@/components/profile/GithubConnection"
 import { GovForumConnection } from "@/components/profile/GovForumConnection"
+
+export const metadata: Metadata = {
+  title: "Profile Connected Apps - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+}
 
 export default async function Page() {
   const session = await auth()
@@ -18,10 +30,7 @@ export default async function Page() {
     <div className="flex flex-col gap-6 text-secondary-foreground">
       <h2 className="text-foreground text-2xl font-semibold">Connected apps</h2>
 
-
       <div className="flex flex-col gap-12">
-
-
         {/* Farcaster */}
         <div className="flex flex-col gap-1">
           <div className="flex items-center space-x-1.5">

--- a/app/src/app/profile/details/page.tsx
+++ b/app/src/app/profile/details/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
@@ -5,6 +6,12 @@ import { EmailConnection } from "@/components/profile/EmailConnection"
 import { updateInteractions } from "@/lib/actions/users"
 
 import { ProfileDetailsContent } from "./content"
+
+export const metadata: Metadata = {
+  title: "Profile Details - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+}
 
 export default async function Page() {
   const session = await auth()

--- a/app/src/app/profile/organizations/[organizationId]/grant-address/page.tsx
+++ b/app/src/app/profile/organizations/[organizationId]/grant-address/page.tsx
@@ -1,10 +1,33 @@
-import { notFound } from "next/navigation"
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
-import posthog from "@/lib/posthog"
+import { getOrganization } from "@/db/organizations"
 
 import { GrantAddressForm } from "./components"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { organizationId: string }
+}): Promise<Metadata> {
+  const organization = await getOrganization({ id: params.organizationId })
+  const title = `Profile Organizations: ${
+    organization?.name ?? ""
+  } | Grant Addresses - OP Atlas`
+  const description = organization?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page() {
   const session = await auth()

--- a/app/src/app/profile/organizations/[organizationId]/page.tsx
+++ b/app/src/app/profile/organizations/[organizationId]/page.tsx
@@ -1,11 +1,33 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import MakeOrganizationForm from "@/components/organizations/MakeOrganizationForm"
 import MakeOrganizationFormHeader from "@/components/organizations/MakeOrganizationFormHeader"
 import { getOrganization } from "@/db/organizations"
 import { getUserById } from "@/db/users"
 import { updateInteractions } from "@/lib/actions/users"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { organizationId: string }
+}): Promise<Metadata> {
+  const organization = await getOrganization({ id: params.organizationId })
+  const title = `Profile Organizations: ${organization?.name ?? ""} - OP Atlas`
+  const description = organization?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export const maxDuration = 120
 

--- a/app/src/app/profile/organizations/new/page.tsx
+++ b/app/src/app/profile/organizations/new/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
@@ -5,6 +6,12 @@ import MakeOrganizationForm from "@/components/organizations/MakeOrganizationFor
 import { getUserById } from "@/db/users"
 
 export const maxDuration = 120
+
+export const metadata: Metadata = {
+  title: "Profile Organizations: New - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+}
 
 export default async function Page() {
   const session = await auth()

--- a/app/src/app/profile/verified-addresses/page.tsx
+++ b/app/src/app/profile/verified-addresses/page.tsx
@@ -1,8 +1,15 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
 import { auth } from "@/auth"
 
 import { VerifiedAddressesContent } from "./content"
+
+export const metadata: Metadata = {
+  title: "Profile Verified Addresses - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+}
 
 export default async function Page() {
   const session = await auth()

--- a/app/src/app/project/[projectId]/page.tsx
+++ b/app/src/app/project/[projectId]/page.tsx
@@ -1,8 +1,9 @@
-import { notFound, redirect } from "next/navigation"
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import TrackedExtendedLink from "@/components/common/TrackedExtendedLink"
-import { getUserById } from "@/db/users"
 import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
 import { getProjectMetrics } from "@/lib/oso"
@@ -20,6 +21,29 @@ import {
 interface PageProps {
   params: {
     projectId: string
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
   }
 }
 

--- a/app/src/app/projects/[projectId]/contracts/page.tsx
+++ b/app/src/app/projects/[projectId]/contracts/page.tsx
@@ -1,9 +1,35 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import { ContractsForm } from "@/components/projects/contracts/ContractsForm"
 import { getProjectContracts } from "@/db/projects"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Contracts: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page({
   params,

--- a/app/src/app/projects/[projectId]/contributors/page.tsx
+++ b/app/src/app/projects/[projectId]/contributors/page.tsx
@@ -1,9 +1,35 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import TeamForm from "@/components/projects/teams/TeamForm"
 import { getConsolidatedProjectTeam, getProject } from "@/db/projects"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Contributors: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page({
   params,

--- a/app/src/app/projects/[projectId]/details/page.tsx
+++ b/app/src/app/projects/[projectId]/details/page.tsx
@@ -1,11 +1,36 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import ProjectDetailsForm from "@/components/projects/details/ProjectDetailsForm"
 import { getAdminOrganizations } from "@/db/organizations"
 import { getProject } from "@/db/projects"
-import { getUserById } from "@/db/users"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Details: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page({
   params,

--- a/app/src/app/projects/[projectId]/grant-address/page.tsx
+++ b/app/src/app/projects/[projectId]/grant-address/page.tsx
@@ -1,12 +1,38 @@
+import { Metadata } from "next"
 import Link from "next/link"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import { Button } from "@/components/common/Button"
 import GrantDeliveryAddress from "@/components/projects/rewards/GrantDeliveryAddress"
 import { getKycTeamForProject } from "@/db/projects"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 
 import { AddGrantDeliveryAddressContainer } from "./components"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Grant-address: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page({
   params,

--- a/app/src/app/projects/[projectId]/grants/page.tsx
+++ b/app/src/app/projects/[projectId]/grants/page.tsx
@@ -1,9 +1,35 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import { GrantsForm } from "@/components/projects/grants/GrantsForm"
 import { getProject } from "@/db/projects"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Grants: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page({
   params,

--- a/app/src/app/projects/[projectId]/publish/page.tsx
+++ b/app/src/app/projects/[projectId]/publish/page.tsx
@@ -1,9 +1,35 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import { PublishForm } from "@/components/projects/publish/PublishForm"
 import { getProject, getProjectContracts } from "@/db/projects"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Publish: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export const maxDuration = 120
 

--- a/app/src/app/projects/[projectId]/repos/page.tsx
+++ b/app/src/app/projects/[projectId]/repos/page.tsx
@@ -1,9 +1,35 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import { ReposForm } from "@/components/projects/repos/ReposForm"
 import { getProject } from "@/db/projects"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Repos: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page({
   params,

--- a/app/src/app/projects/[projectId]/rewards/page.tsx
+++ b/app/src/app/projects/[projectId]/rewards/page.tsx
@@ -1,11 +1,37 @@
+import { Metadata } from "next"
 import { redirect } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import { auth } from "@/auth"
 import { RewardsSection } from "@/components/projects/rewards/RewardsSection"
 import { getConsolidatedProjectTeam, getProject } from "@/db/projects"
 import { getProjectRecurringRewards } from "@/db/rewards"
+import { getPublicProjectAction } from "@/lib/actions/projects"
 import { verifyMembership } from "@/lib/actions/utils"
 import { formatRecurringRewards } from "@/lib/utils/rewards"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    projectId: string
+  }
+}): Promise<Metadata> {
+  const project = await getPublicProjectAction({ projectId: params.projectId })
+
+  const title = `Project Rewards: ${project?.name ?? ""} - OP Atlas`
+  const description = project?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
+  }
+}
 
 export default async function Page({
   params,

--- a/app/src/app/projects/new/page.tsx
+++ b/app/src/app/projects/new/page.tsx
@@ -7,6 +7,11 @@ import { ProjectStatusSidebar } from "@/components/projects/ProjectStatusSidebar
 import { getAdminOrganizations } from "@/db/organizations"
 
 export const maxDuration = 60
+export const metadata = {
+  title: "Projects: New - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+}
 
 export default async function Page() {
   const session = await auth()

--- a/app/src/app/proposals/[proposalId]/page.tsx
+++ b/app/src/app/proposals/[proposalId]/page.tsx
@@ -1,11 +1,35 @@
+import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
+import { sharedMetadata } from "@/app/shared-metadata"
 import ProposalPage from "@/components/proposals/proposalPage/ProposalPage"
 import { getProposal } from "@/lib/proposals"
 
 interface PageProps {
   params: {
     proposalId: string
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: {
+    proposalId: string
+  }
+}): Promise<Metadata> {
+  const proposal = await getProposal(params.proposalId)
+  const title = `Proposals: ${proposal?.markdowntitle ?? ""} - OP Atlas`
+  const description = proposal?.description ?? ""
+  return {
+    ...sharedMetadata,
+    title,
+    description,
+    openGraph: {
+      ...sharedMetadata.openGraph,
+      title,
+      description,
+    },
   }
 }
 

--- a/app/src/app/rounds/page.tsx
+++ b/app/src/app/rounds/page.tsx
@@ -1,8 +1,18 @@
+import { Metadata } from "next"
+
 import { auth } from "@/auth"
 import { Rounds } from "@/components/rounds/Rounds"
 import { getUserById } from "@/db/users"
 import { updateInteractions } from "@/lib/actions/users"
 
+export const metadata: Metadata = {
+  title: "Rounds - OP Atlas",
+  description:
+    "Sign up on OP Atlas to vote for Citizen's House proposals, Retro Funding, and more.",
+  openGraph: {
+    title: "Rounds - OP Atlas",
+  },
+}
 export default async function Page() {
   const session = await auth()
 


### PR DESCRIPTION
This PR added titles meta data to individual pages on the site either by updating metadata statically, or dynamically reign it based on id attributes, depending on the page.