### PR TITLE
Split key:value pairs when recording fails only for value.

### DIFF
--- a/app/src/components/proposals/proposalPage/VotingSidebar/votingColumn/VotingColumn.tsx
+++ b/app/src/components/proposals/proposalPage/VotingSidebar/votingColumn/VotingColumn.tsx
@@ -739,7 +739,7 @@ const VotingColumn = ({ proposalData }: { proposalData: ProposalData }) => {
             }
           }}
           onVoteSubmit={(vote) => {
-            track("Citizen Voting Questionnaire Submitted", { vote })
+            track("Citizen Voting Questionnaire Submitted", { vote: vote })
             setShowVoteQuestionnaire(false)
             setQuestionnaireWasCancelled(false) // User submitted
             setHasSubmittedVote(true) // Mark that the user has submitted a vote


### PR DESCRIPTION
Possible fix for vote values not being included in the mixpanel event.