### PR TITLE
fix: Make profile completion callout user-specific

### DIFF
--- a/app/src/components/dashboard/index.tsx
+++ b/app/src/components/dashboard/index.tsx
@@ -48,8 +48,10 @@ const Dashboard = ({
   organizations?: UserOrganizationsWithDetails[]
   adminProjects: ProjectWithDetails[]
 }) => {
+  // Use last 16 chars of privyDid for user-specific cookie
+  const userIdentifier = user.privyDid ? user.privyDid.slice(-16) : 'default'
   const completeProfileAccordionDismissed = document.cookie.includes(
-    "completeProfileAccordionDismissed",
+    `completeProfileAccordionDismissed_${userIdentifier}`,
   )
   const [
     isCompleteProfileAccordionDismissed,

--- a/app/src/components/profile/CompleteProfileCallout.tsx
+++ b/app/src/components/profile/CompleteProfileCallout.tsx
@@ -38,8 +38,10 @@ export function CompleteProfileCallout({
   const isComplete = progress === 100
 
   const onDismiss = () => {
+    // Use last 16 chars of privyDid for user-specific cookie (30 days expiry)
+    const userIdentifier = user.privyDid ? user.privyDid.slice(-16) : 'default'
     document.cookie =
-      "completeProfileAccordionDismissed=true; max-age=31536000; path=/"
+      `completeProfileAccordionDismissed_${userIdentifier}=true; max-age=2592000; path=/`
     setIsCompleteProfileAccordionDismissed(true)
   }
 


### PR DESCRIPTION
- Changed cookie to be user-specific using last 16 chars of privyDid
- Reduced cookie expiry from 1 year to 30 days
- Fixes issue where new accounts don't see "Complete your profile" section