### PR TITLE
fix(KYC): OPAG-103 optional backfill for missing RewardClaims via env flag

### DIFF
--- a/app/src/db/rewards.ts
+++ b/app/src/db/rewards.ts
@@ -242,6 +242,19 @@ export async function updateClaim(
   })
 }
 
+export async function ensureClaim(rewardId: string) {
+  return prisma.rewardClaim.upsert({
+    where: {
+      rewardId,
+    },
+    update: {},
+    create: {
+      rewardId,
+      status: "pending",
+    },
+  })
+}
+
 async function getClaimByRewardIdFn({ rewardId }: { rewardId: string }) {
   return prisma.rewardClaim.findFirst({
     where: {


### PR DESCRIPTION
### Description
This PR adds an optional backfill for missing RewardClaims via env flag for KYC statuses. Some R4–R6 KYC entries “bypassed Typeform” and have no `RewardClaim`, so the CRON skips them and Retool does not reflect their status.

### Solution
- Optional backfill to create missing `RewardClaim` during CSV import.
- Update `kycStatus` and, when applicable, `tokenStreamClaimableAt`.
- Add import metrics in logs.

### Changes
- `app/src/db/rewards.ts`: add `ensureClaim(rewardId)` (upsert to `pending`).
- `app/src/lib/actions/kyc.ts`:
  - Flag: `OP_ATLAS_KYC_BACKFILL_MISSING_CLAIMS` (default `false`).
  - Conditional backfill via `ensureClaim`.
  - Metrics: `processed`, `updated`, `unchanged`, `createdClaims`, `skippedNoReward`, `skippedNoClaim`.

### Flag / Config
- Env var: `OP_ATLAS_KYC_BACKFILL_MISSING_CLAIMS`
- Default: `false`
- When `true`: if a `Reward` exists but no `RewardClaim`, create one (`pending`) and then apply `kycStatus`.

### Idempotency & Safety
- `ensureClaim` (upsert by `rewardId`) + `updateClaim` (update by `rewardId`).
- Re-running the CRON does not duplicate or corrupt state.
- Instant rollback: set the flag to `false`.

### Out of scope
- CSV rows without `reward_id` are still ignored; they require data fixes or a separate path.

### Testing / QA
1) Staging
- Set `OP_ATLAS_KYC_BACKFILL_MISSING_CLAIMS=true`.
- Run KYC CRON and check logs.
- Validate Retool shows updated statuses/counts.

2) Optional validation query:
```sql
SELECT fr."roundId", COUNT(*) AS cnt
FROM "FundingReward" fr
LEFT JOIN "RewardClaim" rc ON rc."rewardId" = fr.id
WHERE fr."roundId" IN ('4','5','6')
  AND (rc."rewardId" IS NULL OR rc."kycStatus" IS NULL)
GROUP BY fr."roundId";
```

### Risks
- Large backfill if CSV contains unexpected rows. Mitigations: flag off by default, run in staging first, validate samples.

### Rollout
- [x] Merge with flag `false`.
- [x] Enable in staging, run CRON, validate 5–10 samples (Waiting Julian input this monday to validate).
- [x] Enable in prod and run CRON if OK.
- [x] Optionally disable flag after initial backfill.
- [x] Check Retool reflects changes via `RewardClaim` updates and check server logs.