### PR TITLE
fix(rewards): detect active Superfluid stream 

### DIFF
--- a/app/src/components/projects/rewards/RecurringRewardAccordion.tsx
+++ b/app/src/components/projects/rewards/RecurringRewardAccordion.tsx
@@ -51,12 +51,15 @@ const RewardAccordion = ({
   const linkToStream =
     teamVerified &&
     sortedStreams[0]?.id &&
-    sortedStreams[0]?.receiver === reward.kycTeam?.walletAddress &&
+    sortedStreams[0]?.receiver?.toLowerCase() ===
+      reward.kycTeam?.walletAddress?.toLowerCase() &&
     `${SUPERFLUID_STREAM_URL}${sortedStreams[0]?.id}`
 
   const stoppedStreams = teamVerified
     ? sortedStreams.filter(
-        (stream) => stream.receiver !== reward.kycTeam?.walletAddress,
+        (stream) =>
+          stream.receiver?.toLowerCase() !==
+          reward.kycTeam?.walletAddress?.toLowerCase(),
       )
     : sortedStreams
 


### PR DESCRIPTION
## Summary
- **Fix:** Normalize receiver/walletAddress casing in RecurringRewardAccordion to detect active streams.
- **Impact:** Stops showing “7th/22nd” banner when a stream exists; shows “View on Superfluid”.
- **Scope:** UI only, 1 file changed, low risk.