### PR TITLE
Update project metadata to return only for published projects

### DIFF
--- a/app/src/db/projects.ts
+++ b/app/src/db/projects.ts
@@ -2115,7 +2115,7 @@ export const getPublicProject = cache(async (projectId: string) => {
 
 export const getProjectMetadata = cache(async (projectId: string) => {
   return prisma.project.findFirst({
-    where: { id: projectId },
+    where: { id: projectId, snapshots: { some: {} } },
     select: {
       id: true,
       name: true,


### PR DESCRIPTION
Will now only return projects with published snapshot data.