### PR TITLE
Allow dots (.eth) in GovForum URLs

### DIFF
--- a/app/src/components/profile/GovForumConnection.tsx
+++ b/app/src/components/profile/GovForumConnection.tsx
@@ -30,7 +30,7 @@ export function GovForumConnection({ userId }: { userId: string }) {
   const [isEditing, setIsEditing] = useState(false)
 
   const isValidGovForumUrl = (url: string) => {
-    const pattern = /^https:\/\/gov\.optimism\.io\/u\/[a-zA-Z0-9-_]+\/summary$/
+    const pattern = /^https:\/\/gov\.optimism\.io\/u\/[a-zA-Z0-9-_.]+\/summary$/
     return pattern.test(url)
   }
 


### PR DESCRIPTION
Ensured that GovForum URLs accept `.eth`