### PR TITLE
Switch to check entire window

### DIFF
--- a/app/src/app/governance/roles/[roleId]/components/SidebarApplications.tsx
+++ b/app/src/app/governance/roles/[roleId]/components/SidebarApplications.tsx
@@ -40,7 +40,7 @@ export default function SidebarApplications({
     isEndorsementPhase ||
     (SC_ALLOW_APPROVAL_DURING_NOMINATION && isNominationPhase)
   const { data: counts } = useEndorsementCounts(role.id, `role-${role.id}`, {
-    enabled: isEndorsementPhase,
+    enabled: withinWindow,
   })
 
   const isTop100 = Boolean(t100?.top100)
@@ -122,7 +122,7 @@ export default function SidebarApplications({
                   showApprove={!loadingTop && isTop100 && withinWindow}
                   roleId={role.id}
                   count={
-                    isEndorsementPhase
+                    withinWindow
                       ? counts?.find(
                           (c) => c.nomineeApplicationId === application.id,
                         )?.count || 0
@@ -136,7 +136,7 @@ export default function SidebarApplications({
                   showApprove={!loadingTop && isTop100 && withinWindow}
                   roleId={role.id}
                   count={
-                    isEndorsementPhase
+                    withinWindow
                       ? counts?.find(
                           (c) => c.nomineeApplicationId === application.id,
                         )?.count || 0


### PR DESCRIPTION
 # Summary

  - Fixed endorsement counts not displaying in the UI when approvals are made during the nomination phase with the `SC_ALLOW_APPROVAL_DURING_NOMINATION` feature flag enabled

#  Problem

  When the SC_ALLOW_APPROVAL_DURING_NOMINATION feature flag is enabled, Top 100 delegates can create endorsements during both the nomination and endorsement phases. However, the UI was only
  fetching and displaying endorsement counts during the endorsement phase (isEndorsementPhase), causing endorsements created during the nomination phase to exist in the database but not appear in
   the UI.

#  Solution

  Updated SidebarApplications.tsx to use withinWindow instead of isEndorsementPhase when:
  1. Enabling the useEndorsementCounts query (line 43)
  2. Determining whether to display the count badge for candidates (lines 125 and 139)

  The withinWindow variable already correctly accounts for both phases when the feature flag is enabled:
  const withinWindow =
    isEndorsementPhase ||
    (SC_ALLOW_APPROVAL_DURING_NOMINATION && isNominationPhase)

  This ensures endorsement counts are fetched and displayed during both the nomination phase (when the flag is enabled) and the endorsement phase.

 # Test plan

  - Verify endorsement counts display correctly during nomination phase when SC_ALLOW_APPROVAL_DURING_NOMINATION is enabled
  - Verify endorsement counts continue to display correctly during endorsement phase
  - Verify counts are not displayed when outside the approval window