### PR TITLE
fix: use new oso api domain

### DIFF
--- a/app/codegen.ts
+++ b/app/codegen.ts
@@ -4,7 +4,7 @@ import type { CodegenConfig } from "@graphql-codegen/cli"
 
 const config: CodegenConfig = {
   schema: {
-    "https://www.opensource.observer/api/v1/graphql": {
+    "https://www.oso.xyz/api/v1/graphql": {
       headers: {
         Authorization: `Bearer ${process.env.OSO_AUTH_TOKEN ?? ""}`,
       },

--- a/app/src/components/profile/public/ProfileGithubProximity.tsx
+++ b/app/src/components/profile/public/ProfileGithubProximity.tsx
@@ -143,7 +143,7 @@ function ProfileGithubProximity({ user }: { user: UserWithAddresses }) {
                 </a>{" "}
                 and{" "}
                 <a
-                  href="https://docs.opensource.observer/docs/projects/"
+                  href="https://docs.oso.xyz/docs/projects/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-gray-500 underline hover:text-gray-700"

--- a/app/src/components/projects/contracts/ContractsForm.tsx
+++ b/app/src/components/projects/contracts/ContractsForm.tsx
@@ -288,7 +288,7 @@ export function ContractsForm({ project }: ContractsFormProps) {
             However, if you&apos;ve lost your deployer keys, you can complete
             this step by{" "}
             <ExternalLink
-              href="https://www.opensource.observer"
+              href="https://www.oso.xyz"
               className="underline"
             >
               adding your project to Open Source Observer.

--- a/app/src/lib/oso-client.ts
+++ b/app/src/lib/oso-client.ts
@@ -15,7 +15,7 @@ class OsoClient {
   private headers: Record<string, string>
 
   private constructor(
-    endpoint: string = "https://www.opensource.observer/api/v1/graphql",
+    endpoint: string = "https://www.oso.xyz/api/v1/graphql",
   ) {
     this.endpoint = endpoint
     this.headers = {

--- a/app/src/lib/oso/index.ts
+++ b/app/src/lib/oso/index.ts
@@ -84,7 +84,7 @@ class InstrumentedGraphQLClient extends GraphQLClient {
 }
 
 export const osoClient = new InstrumentedGraphQLClient(
-  "https://www.opensource.observer/api/v1/graphql",
+  "https://www.oso.xyz/api/v1/graphql",
   {
     headers: {
       Authorization: `Bearer ${process.env.OSO_AUTH_TOKEN}`,


### PR DESCRIPTION
Hi Agora Team 😊

The opensource observer team is changing our domains to `oso.xyz`. Eventually we may turn off the old domain but for now both are working. I'm not sure if this is all of your references to `www.opensource.observer`. Let me know if I missed anything, I can fix it. 