### PR TITLE
Fix stale /contracts links after contracts section removal

### DIFF
--- a/app/src/app/project/[projectId]/components/Mission/OnchainBuilderMission/index.tsx
+++ b/app/src/app/project/[projectId]/components/Mission/OnchainBuilderMission/index.tsx
@@ -292,7 +292,7 @@ export default function OnchainBuilderMission({
                     For TVL rewards,{" "}
                     <TrackedLink
                       className="underline"
-                      href={`/projects/${projectId ?? ""}/contracts`}
+                      href={`/projects/${projectId ?? ""}/details`}
                       eventName="Link Click"
                       eventData={{
                         projectId: projectId ?? "",

--- a/app/src/components/projects/repos/ReposForm.tsx
+++ b/app/src/components/projects/repos/ReposForm.tsx
@@ -228,7 +228,7 @@ export const ReposForm = ({ project }: { project: ProjectWithFullDetails }) => {
         ])
 
         // Both Save and Next buttons should advance to the next step
-        router.push(`/projects/${project.id}/contracts`)
+        router.push(`/projects/${project.id}/grants`)
         setIsSaving(false)
         // form.reset({ links, githubRepos: projectRepos })
         toast.success("Project saved")


### PR DESCRIPTION
- **ReposForm save**: was pushing to `/projects/[id]/contracts` (now a stub redirect to `/details`), causing a redirect flash. Now routes directly to `/grants`, the actual next wizard step after Repos.
- **OnchainBuilderMission TVL alert**: the "provide a link to your DeFiLlama adapter" link pointed at `/contracts`. Repointed to `/details` (where `/contracts` was redirecting anyway) to drop the flash.